### PR TITLE
Update Loom_MAX31856.cpp

### DIFF
--- a/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.cpp
+++ b/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.cpp
@@ -2,7 +2,7 @@
 #include "Logger.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-Loom_MAX31856::Loom_MAX31856(Manager& man, int samples, int chip_select) : Module("MAX31856"), manInst(&man), maxthermo(10), num_samples(samples) {
+Loom_MAX31856::Loom_MAX31856(Manager& man, int samples, int chip_select) : Module("MAX31856"), manInst(&man), maxthermo(10,11,12,13), num_samples(samples) {
     manInst->registerModule(this);
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.cpp
+++ b/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.cpp
@@ -2,7 +2,7 @@
 #include "Logger.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-Loom_MAX31856::Loom_MAX31856(Manager& man, int samples, int chip_select) : Module("MAX31856"), manInst(&man), maxthermo(10,11,12,13), num_samples(samples) {
+Loom_MAX31856::Loom_MAX31856(Manager& man, int samples, int chip_select, int mosi, int miso, int sclk) : Module("MAX31856"), manInst(&man), maxthermo(chip_select, mosi, miso, sclk), num_samples(samples) {
     manInst->registerModule(this);
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.h
+++ b/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.h
@@ -27,8 +27,11 @@ class Loom_MAX31856 : public Module{
          * @param man Reference to the manager
          * @param chip_select What pin SPI pin to use
          * @param num_samples The number of samples to collect and average
+         * @param mosi
+         * @param miso
+         * @param sclk
          */ 
-        Loom_MAX31856(Manager& man, int chip_select = 10, int samples = 1);
+        Loom_MAX31856(Manager& man, int chip_select = 10, int samples = 1, int mosi = 11, int miso = 12, int sclk = 13 );
 
         /**
          * Get the recorded temperature


### PR DESCRIPTION
Making this changed allowed for a system I was working on to stop getting null temperatures out of the MAX31856 and to start getting real temperatures. maxthermo is the instance of the adafruit max31856 library and needs 4 spi pins assigned. Right now only the cs pin is assigned as far as I can tell. 

I'm not sure which pins get assigned by default.