### PR TITLE
Stability improvement patch

### DIFF
--- a/examples/Hypnos/Adalogger_Sleep/Adalogger_Sleep.ino
+++ b/examples/Hypnos/Adalogger_Sleep/Adalogger_Sleep.ino
@@ -36,6 +36,8 @@ void setup() {
 }
 
 void loop() {
+  // Set the RTC interrupt alarm to wake the device in 10 seconds, done at top so evenly spaced sample periods 
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
 
   // Measure and package data
   manager.measure();
@@ -47,8 +49,7 @@ void loop() {
   // Log the data to the SD card              
   hypnos.logToSD();
 
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
+  
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Hypnos/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
+++ b/examples/Hypnos/Hypnos_SD_Sleep/Hypnos_SD_Sleep.ino
@@ -38,6 +38,9 @@ void setup() {
 
 void loop() {
 
+  // Set the RTC interrupt alarm to wake the device in 10 seconds, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
+
   // Measure and package data
   manager.measure();
   manager.package();
@@ -48,8 +51,7 @@ void loop() {
   // Log the data to the SD card              
   hypnos.logToSD();
 
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
+  
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Hypnos/Hypnos_SD_Sleep_Interval_From_SD/Hypnos_SD_Sleep_Interval_From_SD.ino
+++ b/examples/Hypnos/Hypnos_SD_Sleep_Interval_From_SD/Hypnos_SD_Sleep_Interval_From_SD.ino
@@ -39,15 +39,15 @@ void setup() {
 }
 
 void loop() {
+
+  // Set the RTC interrupt alarm to wake the device in 10 seconds
+  hypnos.setInterruptDuration(sleepInterval);
   
   // Print the current JSON packet
   manager.display_data();            
 
   // Log the data to the SD card              
   hypnos.logToSD();
-
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(sleepInterval);
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Internet/Logging/LTEBatch/LTEBatch.ino
+++ b/examples/Internet/Logging/LTEBatch/LTEBatch.ino
@@ -46,6 +46,9 @@ void setup() {
 }
 
 void loop() {
+  // Set the RTC interrupt alarm to wake the device in 10 seconds
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
+
   // Package data
   manager.package();
 
@@ -58,8 +61,7 @@ void loop() {
   // Pass batch SD along to the MQTT module
   mqtt.publish(batchSD);
   
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
+  
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/Evaporometer/Evaporometer.ino
+++ b/examples/Lab Examples/Evaporometer/Evaporometer.ino
@@ -36,6 +36,10 @@ void setup(){
 }
 
 void loop(){
+
+  // Set the RTC interrupt alarm to wake the device in 30 seconds, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 30));
+
   // Measure and package the data from the sensors
   manager.measure();
   manager.package();
@@ -45,9 +49,6 @@ void loop(){
 
   // Log the data to the SD card
   hypnos.logToSD();
-
-  // Set the RTC interrupt alarm to wake the device in 30 seconds
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 30));
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/FloDar/FloDar.ino
+++ b/examples/Lab Examples/FloDar/FloDar.ino
@@ -41,6 +41,9 @@ void setup() {
 
 void loop() {
 
+  // Set the RTC interrupt alarm to wake the device in 10 seconds, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
+
   // Measure and package data
   manager.measure();
   manager.package();
@@ -51,9 +54,7 @@ void loop() {
   // Log the data to the SD card              
   hypnos.logToSD();
 
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
-
+  
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();
   

--- a/examples/Lab Examples/SmartRock/SmartRock/SmartRock.ino
+++ b/examples/Lab Examples/SmartRock/SmartRock/SmartRock.ino
@@ -43,6 +43,9 @@ void setup() {
 
 void loop() {
 
+  // Set the RTC interrupt alarm to wake the device in 10 seconds, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(sleepInterval);
+
   // Measure and package the data
   manager.measure();
   manager.package();
@@ -57,9 +60,6 @@ void loop() {
 
   // Log the data to the SD card              
   hypnos.logToSD();
-
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(sleepInterval);
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/SmartRock/SmartRock2.5/SmartRock2.5.ino
+++ b/examples/Lab Examples/SmartRock/SmartRock2.5/SmartRock2.5.ino
@@ -44,6 +44,9 @@ void setup() {
 }
 
 void loop() {
+  
+  // Set the RTC interrupt alarm to wake the device in 10 seconds, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(sleepInterval);
 
   // Measure and package the data
   manager.measure();
@@ -55,8 +58,6 @@ void loop() {
   // Log the data to the SD card              
   hypnos.logToSD();
 
-  // Set the RTC interrupt alarm to wake the device in 10 seconds
-  hypnos.setInterruptDuration(sleepInterval);
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/Wattson/Wattson.ino
+++ b/examples/Lab Examples/Wattson/Wattson.ino
@@ -17,13 +17,16 @@
 Manager manager("Device", 1);
 //Loom_WIFI wifi(manager, CommunicationMode::AP); // For AP
 Loom_WIFI wifi(manager, CommunicationMode::CLIENT, SECRET_SSID, SECRET_PASS); // For Client
+
+// Create a new instance of max this takes in the WiFi object so we can communicate with the computer in addition to adding a controllable neopixel
 Loom_Max maxMsp(manager, wifi, new Loom_Neopixel());
 
 Loom_MPU6050 mpu(manager);
 // Read the battery voltage and A0 and A1
 Loom_Analog analog(manager, A0, A1);
+
 // Reads the button on pin 10
-Loom_Digital digital(manager, 10);
+Loom_Digital digital(manager, INPUT_PULLUP, 10);
 
 void setup() {
 

--- a/examples/Lab Examples/Wattson/arduino_secrets.h
+++ b/examples/Lab Examples/Wattson/arduino_secrets.h
@@ -1,0 +1,2 @@
+#define SECRET_SSID ""
+#define SECRET_PASS ""

--- a/examples/Lab Examples/WeatherChimes/WeatherChimes4G/WeatherChimes4G.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimes4G/WeatherChimes4G.ino
@@ -79,6 +79,9 @@ void setup() {
 
 void loop() {
 
+  // Set the RTC interrupt alarm to wake the device in 15 min, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
+
   // Measure and package the data
   manager.measure();
   manager.package();
@@ -94,9 +97,6 @@ void loop() {
 
   // Publish the collected data to MQTT
   mqtt.publish();
-
-  // Set the RTC interrupt alarm to wake the device in 15 min
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
@@ -75,7 +75,7 @@ void setup() {
   ENABLE_FUNC_SUMMARIES;
 
   // Set the interrupt pin to pullup
-  pinMode(INT_PIN, INPUT_PULLUP);
+  pinMode(INT_PIN, INPUT_PULLDOWN);
 
   // Wait 20 seconds for the serial console to open
   manager.beginSerial();
@@ -101,6 +101,9 @@ void setup() {
 void loop() {
 
   if(sampleFlag){
+    // Set the RTC interrupt alarm to wake the device in 15 min
+    hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
+
     // Measure and package the data
     manager.measure();
     manager.package();
@@ -116,9 +119,6 @@ void loop() {
 
     // Publish the collected data to MQTT
     mqtt.publish();
-
-    // Set the RTC interrupt alarm to wake the device in 15 min
-    hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
 
     // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
     hypnos.reattachRTCInterrupt();

--- a/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
@@ -101,7 +101,7 @@ void setup() {
 void loop() {
 
   if(sampleFlag){
-    // Set the RTC interrupt alarm to wake the device in 15 min
+    // Set the RTC interrupt alarm to wake the device in 15 min, this should be done as soon as the device enters sampling mode for consistant sleep cycles
     hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
 
     // Measure and package the data

--- a/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucket/WeatherChimesTippingBucket.ino
@@ -75,7 +75,7 @@ void setup() {
   ENABLE_FUNC_SUMMARIES;
 
   // Set the interrupt pin to pullup
-  pinMode(INT_PIN, INPUT_PULLDOWN);
+  pinMode(INT_PIN, INPUT);
 
   // Wait 20 seconds for the serial console to open
   manager.beginSerial();

--- a/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucketI2C/WeatherChimesTippingBucketI2C.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimesTippingBucketI2C/WeatherChimesTippingBucketI2C.ino
@@ -90,7 +90,7 @@ void loop() {
   // Publish the collected data to MQTT
   mqtt.publish();
 
-  // Set the RTC interrupt alarm to wake the device in 15 min
+  // Set the RTC interrupt alarm to wake the device in 15 min, at the top to schedule next interrupt asap
   hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers

--- a/examples/Lab Examples/WeatherChimes/WeatherChimesWifi/WeatherChimesWiFi.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimesWifi/WeatherChimesWiFi.ino
@@ -79,6 +79,9 @@ void setup() {
 
 void loop() {
 
+  // Set the RTC interrupt alarm to wake the device in 15 min, at the top to schedule next interrupt asap
+  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
+
   // Measure and package the data
   manager.measure();
   manager.package();
@@ -95,9 +98,7 @@ void loop() {
   // Publish the collected data to MQTT
   mqtt.publish();
 
-  // Set the RTC interrupt alarm to wake the device in 15 min
-  hypnos.setInterruptDuration(TimeSpan(0, 0, 15, 0));
-
+ 
   // Reattach to the interrupt after we have set the alarm so we can have repeat triggers
   hypnos.reattachRTCInterrupt();
   

--- a/examples/Sensors/Digital/Digital.ino
+++ b/examples/Sensors/Digital/Digital.ino
@@ -12,8 +12,8 @@
 
 Manager manager("Device", 1);
 
-// Reads the battery voltage
-Loom_Digital digital(manager, 12, 11);
+// Sets the pinMode of pin 12 and 11 to INPUT_PULLUP and then reads values from the pins
+Loom_Digital digital(manager, INPUT_PULLUP, 12, 11);
 
 void setup() {
 
@@ -25,7 +25,6 @@ void setup() {
 }
 
 void loop() {
-  // put your main code here, to run repeatedly:
 
   // Measure the data from the sensors
   manager.measure();

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -366,22 +366,25 @@ void Loom_Hypnos::setInterruptDuration(const TimeSpan duration){
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 void Loom_Hypnos::sleep(bool waitForSerial){
-    // Try to power down the active modules
-    if(shouldPowerUp){
-        manInst->power_down();
-        // 50ms delay allows this last message to be sent before the bus disconnects
-        LOG("Entering Standby Sleep...");
-        delay(50);
+
+    // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one
+    if(RTC_DS.getAlarm(1) > RTC_DS.now()){
+        // Try to power down the active modules
+        if(shouldPowerUp){
+            manInst->power_down();
+            // 50ms delay allows this last message to be sent before the bus disconnects
+            LOG("Entering Standby Sleep...");
+            delay(50);
+        }
+        
+        disable();
+        pre_sleep();                    // Pre-sleep cleanup
+        shouldPowerUp = true;
+        LowPower.sleep();               // Go to sleep and hang
+        post_sleep(waitForSerial);      // Wake up
+    }else{
+        WARNING("If the alarm was set to a time less than the current time we don't want to sleep before a new time was set");
     }
-
-
-    
-    
-    disable();
-    pre_sleep();                    // Pre-sleep cleanup
-    shouldPowerUp = true;
-    LowPower.sleep();               // Go to sleep and hang
-    post_sleep(waitForSerial);      // Wake up
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -383,7 +383,7 @@ void Loom_Hypnos::sleep(bool waitForSerial){
         LowPower.sleep();               // Go to sleep and hang
         post_sleep(waitForSerial);      // Wake up
     }else{
-        WARNING("If the alarm was set to a time less than the current time we don't want to sleep before a new time was set");
+        WARNING("Alarm triggered during sample, specified sample duration was too short! Setting new sample time...");
     }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -351,7 +351,6 @@ void Loom_Hypnos::setInterruptDuration(const TimeSpan duration){
     DateTime future(RTC_DS.now() + duration);
     RTC_DS.setAlarm(future);
 
-
     // Print the time that the next interrupt is set to trigger
     snprintf(output, OUTPUT_SIZE, PSTR("Current Time: %s"), RTC_DS.now().text());
     LOG(output);
@@ -369,9 +368,11 @@ void Loom_Hypnos::sleep(bool waitForSerial){
 
     // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one
     if(RTC_DS.getAlarm(1) > RTC_DS.now()){
+
         // Try to power down the active modules
         if(shouldPowerUp){
             manInst->power_down();
+            
             // 50ms delay allows this last message to be sent before the bus disconnects
             LOG("Entering Standby Sleep...");
             delay(50);

--- a/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
+++ b/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
@@ -247,12 +247,14 @@ void Loom_MQTT::loadConfigFromJSON(char* json){
     // Doc to store the JSON data from the SD card in
     StaticJsonDocument<300> doc;
     DeserializationError deserialError = deserializeJson(doc, json);
+    memset(projectServer, '\0', 100);
 
     // Check if an error occurred and if so print it
     if(deserialError != DeserializationError::Ok){
         snprintf_P(output, OUTPUT_SIZE, PSTR("There was an error reading the MQTT credentials from SD: %s"), deserialError.c_str());
         ERROR(output);
     }
+    
 
     // Only update values if not null
     if(!doc["broker"].isNull()){
@@ -260,7 +262,8 @@ void Loom_MQTT::loadConfigFromJSON(char* json){
         strncpy(database_name, doc["database"].as<const char*>(), 100);
         strncpy(username, doc["username"].as<const char*>(), 100);
         strncpy(password, doc["password"].as<const char*>(), 100);
-        strncpy(projectServer, doc["project"].as<const char*>(), 100);
+        if(!doc["project"].isNull())
+            strncpy(projectServer, doc["project"].as<const char*>(), 100);
         port = doc["port"].as<int>();
     }
     

--- a/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
+++ b/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
@@ -269,7 +269,7 @@ void Loom_MQTT::loadConfigFromJSON(char* json){
         strncpy(database_name, doc["database"].as<const char*>(), 100);
 
         // If we dont have a username don't try to update the variables
-        if(!doc["username".isNull()]){
+        if(!doc["username"].isNull()){
             strncpy(username, doc["username"].as<const char*>(), 100);
             strncpy(password, doc["password"].as<const char*>(), 100);
         }

--- a/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
+++ b/src/Internet/Logging/Loom_MQTT/Loom_MQTT.cpp
@@ -247,7 +247,14 @@ void Loom_MQTT::loadConfigFromJSON(char* json){
     // Doc to store the JSON data from the SD card in
     StaticJsonDocument<300> doc;
     DeserializationError deserialError = deserializeJson(doc, json);
+
+    /* 
+        Initialize all to null bytes so they are treated as a 0 length string
+        Issue: https://github.com/OPEnSLab-OSU/Loom-V4/issues/57
+     */
     memset(projectServer, '\0', 100);
+    memset(username, '\0', 100);
+    memset(password, '\0', 100);
 
     // Check if an error occurred and if so print it
     if(deserialError != DeserializationError::Ok){
@@ -260,10 +267,17 @@ void Loom_MQTT::loadConfigFromJSON(char* json){
     if(!doc["broker"].isNull()){
         strncpy(address, doc["broker"].as<const char*>(), 100);
         strncpy(database_name, doc["database"].as<const char*>(), 100);
-        strncpy(username, doc["username"].as<const char*>(), 100);
-        strncpy(password, doc["password"].as<const char*>(), 100);
+
+        // If we dont have a username don't try to update the variables
+        if(!doc["username".isNull()]){
+            strncpy(username, doc["username"].as<const char*>(), 100);
+            strncpy(password, doc["password"].as<const char*>(), 100);
+        }
+       
+        // If there is no project parameter don't update the project
         if(!doc["project"].isNull())
             strncpy(projectServer, doc["project"].as<const char*>(), 100);
+
         port = doc["port"].as<int>();
     }
     

--- a/src/Sensors/Loom_Digital/Loom_Digital.h
+++ b/src/Sensors/Loom_Digital/Loom_Digital.h
@@ -27,13 +27,13 @@ class Loom_Digital : public Module{
          * @param additionalPins Variable length argument allowing you to supply multiple pins
          */ 
         template<typename T, typename... Args>
-        Loom_Digital(Manager& man, T firstPin , Args... additionalPins) : Module("Digital"){
+        Loom_Digital(Manager& man, int pinState, T firstPin , Args... additionalPins) : Module("Digital"){
            get_variadic_parameters(firstPin, additionalPins...);
            manInst = &man;
 
            // Set pin mode on digital pins
            for(int i = 0; i < digitalPins.size(); i++){
-                pinMode(digitalPins[i], INPUT_PULLUP);
+                pinMode(digitalPins[i], pinState);
            }
 
            // Register the module with the manager
@@ -46,12 +46,12 @@ class Loom_Digital : public Module{
          * @param firstPin First digital pin we want to read from
          */ 
         template<typename T>
-        Loom_Digital(Manager& man, T firstPin) : Module("Digital"){
+        Loom_Digital(Manager& man, int pinState, T firstPin) : Module("Digital"){
            digitalPins.push_back(firstPin);
            manInst = &man;
 
            for(int i = 0; i < digitalPins.size(); i++){
-                pinMode(digitalPins[i], INPUT_PULLUP);
+                pinMode(digitalPins[i], pinState);
            }
 
            // Register the module with the manager


### PR DESCRIPTION
This pull request adds checks for Hypnos alarms triggered during the sample period before the next sleep. In addition, it also fixed the failed-to-close message error that would occur with the MQTT client, refer to #57 for details. Also all .setInterruptDuration calls should go at the beginning of the sample period and all examples using them have been updated with the exception of Dendrometer and LilyPad