### PR TITLE
Changed how we handle the RTC alarm check if we didn't power on (NOTHING ELSE SHOULD BE MERGED UNTIL THIS IS COMPLETED)

### DIFF
--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -369,7 +369,7 @@ void Loom_Hypnos::sleep(bool waitForSerial){
     // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one, we need to check if we have powered on already so we dont use the RTC that isn't enabled
     bool hasAlarmTriggered = false;
     if(shouldPowerUp){
-        hasAlarmTriggered = RTC_DS.getAlarm(1) <= RTC_DS.now();
+        hasAlarmTriggered = RTC_DS.getAlarm(1).unixtime() <= RTC_DS.now().unixtime();
     }
     
     if(!hasAlarmTriggered){

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -366,8 +366,13 @@ void Loom_Hypnos::setInterruptDuration(const TimeSpan duration){
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 void Loom_Hypnos::sleep(bool waitForSerial){
 
-    // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one
-    if(RTC_DS.getAlarm(1) > RTC_DS.now()){
+    // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one, we need to check if we have powered on already so we dont use the RTC that isn't enabled
+    bool hasAlarmTriggered = false;
+    if(shouldPowerUp){
+        hasAlarmTriggered = RTC_DS.getAlarm(1) <= RTC_DS.now();
+    }
+    
+    if(!hasAlarmTriggered){
 
         // Try to power down the active modules
         if(shouldPowerUp){
@@ -384,7 +389,7 @@ void Loom_Hypnos::sleep(bool waitForSerial){
         LowPower.sleep();               // Go to sleep and hang
         post_sleep(waitForSerial);      // Wake up
     }else{
-        WARNING("Alarm triggered during sample, specified sample duration was too short! Setting new sample time...");
+        WARNING("Alarm triggered during sample, specified sample duration was too short! Resampling...");
     }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Before going to sleep we would always check the alarm to see if we should enter sleep mode or resample, however, if the device wasn't fully powered on (ie. tipping bucket tip). Attempting to access the RTC would likely result in a hang. So a check has been added to see if the device was actually powered on before calling the RTC methods. It needs to be tested.