### PR TITLE
SDS011 - Getter function

### DIFF
--- a/src/Sensors/Serial/Loom_NOVASDS/Loom_NOVASDS.h
+++ b/src/Sensors/Serial/Loom_NOVASDS/Loom_NOVASDS.h
@@ -22,6 +22,17 @@ class Loom_NOVASDS011: public Module{
 
         Loom_NOVASDS011(Manager& man, HardwareSerial* serial = &Serial1);
 
+        /**
+         * Get PM 2.5 value
+         */ 
+
+        float getPM25() {return pm25; };
+
+        /**
+         * Get PM 10 value
+         */ 
+        float getPM() { return pm10; };
+
     private:
         Manager* manInst;           // Instance of the Manager  
         SDS011 nova;                // Instance of the library

--- a/src/Sensors/Serial/Loom_NOVASDS/Loom_NOVASDS.h
+++ b/src/Sensors/Serial/Loom_NOVASDS/Loom_NOVASDS.h
@@ -31,7 +31,7 @@ class Loom_NOVASDS011: public Module{
         /**
          * Get PM 10 value
          */ 
-        float getPM() { return pm10; };
+        float getPM10() { return pm10; };
 
     private:
         Manager* manInst;           // Instance of the Manager  


### PR DESCRIPTION
Included getter function for the Nova SDS011 Air Quality sensor for end-user access to the PM10 and PM25 values.

**Tested with following code:**

```
#include <Loom_Manager.h>
#include <Logger.h>

#include <Sensors/Serial/Loom_NOVASDS/Loom_NOVASDS.h>

int threshold = 100; 

Manager manager("YourName", 1);

Loom_Hypnos hypnos(manager, HYPNOS_VERSION::ADALOGGER, TIME_ZONE::PST, true);

Loom_NOVASDS011 nova(manager, &Serial1);

void setup() {

  // Start the serial interface
  manager.beginSerial();

  // Enable the hypnos rails
  hypnos.enable();
      // This will log all LOG, ERROR, WARNING and any other logging calls to a file on the SD card
    ENABLE_SD_LOGGING;
    // Enables debug memory usage function summaries that will be logged to the SD card
    ENABLE_FUNC_SUMMARIES;

  // Initialize the manager
  manager.initialize();
}

void loop() {
  // put your main code here, to run repeatedly:

  // Measure the data from the sensors
  manager.measure();

  // Package the data into JSON
  manager.package();

  // Print the JSON document to the Serial monitor
  manager.display_data();

  // Log to the SD card twice and then lay dormant
  hypnos.logToSD();

  if(nova.getPM10() > threshold) // Tested the nova.getPM25 function too
    digitalWrite(LED_BUILTIN, HIGH);  // If True: turn the LED on 
  else
    digitalWrite(LED_BUILTIN, LOW);  // If False: turn the LED off

  // Wait for 5 seconds
  manager.pause(5000);
}
```

**Testing Outcome:**

LED turned on when creating a smoky environment by melting solder. Likewise, the LED turns off once the smoke subsides.