### PR TITLE
Added format logging methods (for a slightly nicer API)

### DIFF
--- a/src/Logger.h
+++ b/src/Logger.h
@@ -13,6 +13,25 @@
 #define ERROR(msg) Logger::getInstance()->errorLog(msg, false, __FILE__, __func__, __LINE__)                // Log an error message
 #define WARNING(msg) Logger::getInstance()->warningLog(msg, false, __FILE__, __func__, __LINE__)            // Log a warning message
 
+// TODO(rwheary): make sure __LINE__ gives expected output
+#define LOGF(msg, ...) do { \
+    char buf[OUTPUT_SIZE]; \
+    snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
+    LOG(buf); \
+} while(0);
+
+#define ERRORF(msg, ...) do { \
+    char buf[OUTPUT_SIZE]; \
+    snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
+    ERROR(buf); \
+} while(0);
+
+#define WARNINGF(msg, ...) do { \
+    char buf[OUTPUT_SIZE]; \
+    snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
+    WARNING(buf); \
+} while(0);
+
 #define ENABLE_SD_LOGGING Logger::getInstance()->enableSD()                                                 // Enable SD logging of debug information
 #define ENABLE_FUNC_SUMMARIES Logger::getInstance()->enableSummaries()                                      // Enable logging of function mem usage summaries
 

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -13,23 +13,23 @@
 #define ERROR(msg) Logger::getInstance()->errorLog(msg, false, __FILE__, __func__, __LINE__)                // Log an error message
 #define WARNING(msg) Logger::getInstance()->warningLog(msg, false, __FILE__, __func__, __LINE__)            // Log a warning message
 
-#define LOGF(msg, ...) do { \
+#define LOGF(msg, ...) { \
     char buf[OUTPUT_SIZE]; \
     snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
     LOG(buf); \
-} while(0);
+}
 
-#define ERRORF(msg, ...) do { \
+#define ERRORF(msg, ...) { \
     char buf[OUTPUT_SIZE]; \
     snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
     ERROR(buf); \
-} while(0);
+}
 
-#define WARNINGF(msg, ...) do { \
+#define WARNINGF(msg, ...) { \
     char buf[OUTPUT_SIZE]; \
     snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \
     WARNING(buf); \
-} while(0);
+}
 
 #define ENABLE_SD_LOGGING Logger::getInstance()->enableSD()                                                 // Enable SD logging of debug information
 #define ENABLE_FUNC_SUMMARIES Logger::getInstance()->enableSummaries()                                      // Enable logging of function mem usage summaries

--- a/src/Logger.h
+++ b/src/Logger.h
@@ -13,7 +13,6 @@
 #define ERROR(msg) Logger::getInstance()->errorLog(msg, false, __FILE__, __func__, __LINE__)                // Log an error message
 #define WARNING(msg) Logger::getInstance()->warningLog(msg, false, __FILE__, __func__, __LINE__)            // Log a warning message
 
-// TODO(rwheary): make sure __LINE__ gives expected output
 #define LOGF(msg, ...) do { \
     char buf[OUTPUT_SIZE]; \
     snprintf_P(buf, sizeof(buf), PSTR(msg), __VA_ARGS__); \


### PR DESCRIPTION
Added 3 new logging methods: `LOGF`, `WARNINGF`, and `ERRORF`, that incorporate `snprintf` functionality directly into the macro.

Instead of:
```cpp
char buffer[OUTPUT_SIZE] = {};
snprintf_P(buffer, sizeof(buffer), PSTR("testing %s %i", "testing", 123);
LOG(buffer);
```
simply write:
```cpp
LOGF("testing %s %i", "testing", 123);
```

Note that the initial message **must** be a string literal for the PSTR macro to work correctly.