### PR TITLE
Sd spi memory read corruption fix

### DIFF
--- a/examples/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.ino
+++ b/examples/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.ino
@@ -1,0 +1,17 @@
+#include <Loom_Manager.h>
+#include <Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.h>
+
+Manager manager("Device", 1);
+Loom_MultiGasSensor gasSensor(manager, 0x77, false);
+
+void setup() {
+  manager.beginSerial();
+  manager.initialize();
+}
+
+void loop() {
+  manager.measure();
+  manager.package();
+  manager.display_data();
+  manager.pause(5000);
+}

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -565,7 +565,6 @@ TimeSpan Loom_Hypnos::getConfigFromSD(const char* fileName){
     char output[OUTPUT_SIZE];
     char* fileRead = sdMan->readFile(fileName);
     DeserializationError deserialError = deserializeJson(doc, fileRead);
-    free(fileRead);
 
     // Create json object to easily pull data from
     JsonObject json = doc.as<JsonObject>();
@@ -595,6 +594,7 @@ TimeSpan Loom_Hypnos::getConfigFromSD(const char* fileName){
             return TimeSpan(0, 0, 20, 0);
         }
     }
+    free(fileRead);
     FUNCTION_END;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.cpp
+++ b/src/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.cpp
@@ -1,0 +1,145 @@
+#include "Loom_MultiGasSensor.h"
+#include "Logger.h"
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+Loom_MultiGasSensor::Loom_MultiGasSensor(
+                            Manager& man,
+                            int address,
+                            bool useMux
+                    ) : I2CDevice("MultiGasSensor"), manInst(&man), gas(&Wire, address) {
+                        module_address = address;
+
+                        // Register the module with the manager
+                        if(!useMux)
+                            manInst->registerModule(this);
+                    }
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+uint8_t Loom_MultiGasSensor::get_gas_i2c(const std::string gasType){
+    if(gasType == "O2")
+        return 0x05;
+    if (gasType == "CO")
+        return 0x04;
+    if (gasType == "H2S")
+        return 0x03;
+    if (gasType == "NO2")
+        return 0x2C;
+    if (gasType == "O3")
+        return 0x2A;
+    if (gasType == "CL2")
+        return 0x31;
+    if (gasType == "NH3")
+        return 0x02;
+    if (gasType == "H2")
+        return 0x06;
+    if (gasType == "HCL")
+        return 0x2E;
+    if (gasType == "SO2")
+        return 0x2B;
+    if (gasType == "HF")
+        return 0x33;
+    if (gasType == "PH3")
+        return 0x45;
+    return 0x00;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+void Loom_MultiGasSensor::initialize() {
+    FUNCTION_START;
+    int retries = 0;
+    gas.setI2cAddr(0x05);
+
+    while (!gas.begin()){
+        ERROR(F("Failed to initialize Gas Sensor! Retrying..."));
+        moduleInitialized = false;
+        delay(1000);
+        retries++;
+        if(retries > DF_MAX_RETRIES){
+            ERROR(F("Failed to initialize Gas Sensor... Check connections and try again!"));
+            break;
+        }
+        moduleInitialized = true;
+    }
+
+    if(moduleInitialized){
+        gas.setTempCompensation(gas.ON);
+        gas.changeAcquireMode(gas.PASSIVITY);
+        delay(1000);
+        LOG(F("Successfully initialized Gas Sensor!"));
+    }
+
+    FUNCTION_END;
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+void Loom_MultiGasSensor::measure() {
+    FUNCTION_START;
+    if(moduleInitialized){
+        // Get the current connection status
+        bool connectionStatus = checkDeviceConnection();
+
+        // If we are connected and we need to reinit
+        if(connectionStatus && needsReinit){
+            initialize();
+            needsReinit = false;
+        }
+
+        // If we are not connected
+        else if(!connectionStatus){
+            ERROR(F("No acknowledge received from the device"));
+            FUNCTION_END;
+            return;
+        }
+        if (gasData != nullptr){
+            delete gasData;
+            gasData = nullptr;
+        }
+
+        gasData = new std::unordered_map<std::string, float>;
+
+        gasData->insert({"CO", 0.0});
+        gasData->insert({"O2", 0.0});
+        gasData->insert({"NH3", 0.0});
+        gasData->insert({"H2S", 0.0});
+        gasData->insert({"NO2", 0.0});
+        gasData->insert({"HCL", 0.0});
+        gasData->insert({"H2", 0.0});
+        gasData->insert({"PH3", 0.0});
+        gasData->insert({"SO2", 0.0});
+        gasData->insert({"O3", 0.0});
+        gasData->insert({"CL2", 0.0});
+        gasData->insert({"HF", 0.0});
+
+        for (auto i = gasData->begin(); i != gasData->end(); ++i){
+            const std::string currentGas = i->first;
+            gas.changeI2cAddrGroup(get_gas_i2c(currentGas));
+            delay(50);
+
+            if (gas.queryGasType() == String(i->first.c_str())){
+                i->second = gas.readGasConcentrationPPM();
+            }
+            else{
+                ERROR(F("Gas type was set but does not query correctly"));
+            }
+        }
+    gasData->insert({"Temperature(C)", gas.readTempC()});
+    }
+    FUNCTION_END;
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+void Loom_MultiGasSensor::package() {
+    FUNCTION_START;
+    if(moduleInitialized && gasData != nullptr){
+        JsonObject json = manInst->get_data_object(getModuleName());
+        for (auto i = gasData->begin(); i != gasData->end(); ++i){
+            json[i->first] = i->second;
+        }
+        delete gasData;
+        gasData = nullptr;
+    }
+    FUNCTION_END;
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.h
+++ b/src/Sensors/I2C/Loom_MultiGasSensor/Loom_MultiGasSensor.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <DFRobot_MultiGasSensor.h>
+#include <unordered_map>
+#include <string.h>
+
+#include "../I2CDevice.h"
+#include "Loom_Manager.h"
+
+#ifndef DF_MAX_RETRIES
+#define DF_MAX_RETRIES 10
+#endif
+
+/**
+ * DFRobot MultiGasSensor
+ *
+ * @author Soren Emmons
+ */
+class Loom_MultiGasSensor : public I2CDevice{
+    protected:
+
+       // Manager controlled functions
+        void measure() override;
+        void initialize() override;
+        void power_up() override {};
+        void power_down() override {};
+        void package() override;
+
+    public:
+        /**
+         * Constructs a new sensor
+         * @param man Reference to the manager that is used to universally package all data
+         * @param address I2C address that is assigned to the sensor
+         */
+        Loom_MultiGasSensor(
+                      Manager& man,
+                      int address = 0x77,
+                      bool useMux = false
+                );
+
+        /**
+         * Get gas type that is currently being recorded
+         */
+        //uint16_t getGasType() {return ; };
+
+        /**
+         * Get the gas concentration that is currently being recorded
+         */
+        //uint16_t getGasConcentration() { return ; };
+
+
+
+    private:
+    uint8_t get_gas_i2c(const std::string gasType);
+
+    Manager* manInst;
+    DFRobot_GAS_I2C gas;
+    bool moduleInitialized = false;
+    bool needsReinit = false;
+    std::unordered_map<std::string, float> *gasData = nullptr;
+};


### PR DESCRIPTION
https://arduinojson.org/v6/api/json/deserializejson/

If the input is a char*, ensure the input buffer stays in memory until the [JsonDocument](https://arduinojson.org/v6/api/jsondocument/) is destructed.

Sd card file was being freed before we were done using the JSON object