### PR TITLE
Sd spi sd corruption fix

### DIFF
--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -564,12 +564,6 @@ TimeSpan Loom_Hypnos::getConfigFromSD(const char* fileName){
     StaticJsonDocument<OUTPUT_SIZE> doc;
     char output[OUTPUT_SIZE];
     char* fileRead = sdMan->readFile(fileName);
-    
-    char fileOutput[OUTPUT_SIZE];
-    snprintf(fileOutput, OUTPUT_SIZE, "%s", fileRead);
-    LOG(fileOutput);
-
-
     DeserializationError deserialError = deserializeJson(doc, fileRead);
 
     // Create json object to easily pull data from

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -571,7 +571,6 @@ TimeSpan Loom_Hypnos::getConfigFromSD(const char* fileName){
 
 
     DeserializationError deserialError = deserializeJson(doc, fileRead);
-    free(fileRead);
 
     // Create json object to easily pull data from
     JsonObject json = doc.as<JsonObject>();
@@ -601,6 +600,7 @@ TimeSpan Loom_Hypnos::getConfigFromSD(const char* fileName){
             return TimeSpan(0, 0, 20, 0);
         }
     }
+    free(fileRead);
     FUNCTION_END;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
fileRead memory was being freed despite the JSON object accessing it in the function. This caused corruption when using a SPI sensor