### PR TITLE
Sen55 fix v2

### DIFF
--- a/examples/Lab Examples/Whisp_Batch_Logging/Whisp_Batch_Logging.ino
+++ b/examples/Lab Examples/Whisp_Batch_Logging/Whisp_Batch_Logging.ino
@@ -24,7 +24,7 @@ Loom_SHT31 sht(manager);
 
 //Connectivity
 Loom_LTE lte(manager, "hologram", "", "");
-Loom_MongoDB mqtt(manager, lte.getClient());
+Loom_MongoDB mqtt(manager, lte);
 //A batch is logged every 5 minutes, so 12 per hour (12 * 6 = 72) so mqtt will publish at batch size of 72/ every 6 hours
 Loom_BatchSD batchSD(hypnos, 72);
 

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -40,7 +40,7 @@ void Loom_Hypnos::package(){
 
     time = getCurrentTime();
     localTime = getLocalTime(time);
-    
+
     dateTime_toString(time, timeStr);
     json["time_utc"] = timeStr;
 
@@ -180,7 +180,7 @@ bool Loom_Hypnos::registerInterrupt(InterruptCallbackFunction isrFunc, int inter
     // If the RTC hasn't already been initialized then do so now if we are trying to schedule an RTC interrupt
     if(!RTC_initialized && interruptPin == 12)
         initializeRTC();
-    
+
     // Make sure a callback function was supplied
     if(isrFunc != nullptr){
 
@@ -475,10 +475,10 @@ void Loom_Hypnos::sleep(bool waitForSerial){
         LOG("Entering Standby Sleep...");
         delay(50);
 
-        // After powering down the devices check if the alarmed time is less than the current time, this means that the alarm may have already triggered
-        uint32_t alarmedTime = RTC_DS.getAlarm(1).unixtime();
-        uint32_t currentTime = RTC_DS.now().unixtime();
-        hasAlarmTriggered = alarmedTime <= currentTime;
+    // After powering down the devices check if the alarmed time is less than the current time, this means that the alarm may have already triggered
+    uint32_t alarmedTime = RTC_DS.getAlarm(1).unixtime();
+    uint32_t currentTime = RTC_DS.now().unixtime();
+    hasAlarmTriggered = alarmedTime <= currentTime;
     }
 
     // If it hasn't we should preform our sleep as before

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -475,10 +475,10 @@ void Loom_Hypnos::sleep(bool waitForSerial){
         LOG("Entering Standby Sleep...");
         delay(50);
 
-    // After powering down the devices check if the alarmed time is less than the current time, this means that the alarm may have already triggered
-    uint32_t alarmedTime = RTC_DS.getAlarm(1).unixtime();
-    uint32_t currentTime = RTC_DS.now().unixtime();
-    hasAlarmTriggered = alarmedTime <= currentTime;
+        // After powering down the devices check if the alarmed time is less than the current time, this means that the alarm may have already triggered
+        uint32_t alarmedTime = RTC_DS.getAlarm(1).unixtime();
+        uint32_t currentTime = RTC_DS.now().unixtime();
+        hasAlarmTriggered = alarmedTime <= currentTime;
     }
 
     // If it hasn't we should preform our sleep as before

--- a/src/Sensors/I2C/Loom_SEN55/Loom_SEN55.cpp
+++ b/src/Sensors/I2C/Loom_SEN55/Loom_SEN55.cpp
@@ -5,8 +5,9 @@
 Loom_SEN55::Loom_SEN55(
                         Manager& man,
                         bool measurePM,
-                        bool useMux
-                    ) : I2CDevice("SEN55"), manInst(&man), measurePM(measurePM){
+                        bool useMux,
+                        bool readNumVals
+                    ) : I2CDevice("SEN55"), manInst(&man), measurePM(measurePM), readNumVals(readNumVals){
 
                         // Register the module with the manager
                         if(!useMux)
@@ -39,25 +40,6 @@ void Loom_SEN55::initialize() {
         LOG("Sensor successfully initialized!");
     }
 
-    /* Determine if we want to measure with the particulate matter readings or not */
-    if(measurePM){
-        error = sen5x.startMeasurement();
-    }
-    else{
-        error = sen5x.startMeasurementWithoutPm();
-    }
-
-    if(error){
-        errorToString(error, errorMessage, OUTPUT_SIZE);
-        snprintf(output, OUTPUT_SIZE, "Error occurred when attempting to collect measurement: %s", errorMessage);
-        ERROR(output);
-        FUNCTION_END;
-        return;
-    }
-
-    // Wait for required one second as described in the readMeasuredValues() documentation
-    LOG("Waiting 10 seconds seconds so that we can warm the sensor up");
-    delay(10000);
     FUNCTION_END;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -67,6 +49,128 @@ void Loom_SEN55::measure() {
     FUNCTION_START;
     char output[OUTPUT_SIZE];
     char sensorError[OUTPUT_SIZE];
+
+    delay(100);
+    // Reset the relevent values for the average calcuation of the PM measurements
+    resetValuesForMeasure();
+
+    // Turn on pm reading if needed
+    if(measurePM){
+        LOG(F("Beginning PM measurement, waiting 2 seconds at each increment for stablizing mesurement..."));
+        uint16_t readErr = sen5x.startMeasurement();
+        float Pm1p0 = 0, Pm2p5 = 0, Pm4p0 = 0, Pm10p0 = 0;
+        float numPm0p5 = 0, numPm1p0 = 0, numPm2p5 = 0, numPm4p0 = 0, numPm10p0 = 0;
+        float particleSize = 0;
+        uint8_t failedReads = 0;
+        for(int i = 0; i < PM_AVERAGE_COUNT; i++){
+            delay(2000);
+
+            bool dataReady = false;
+            sen5x.readDataReady(dataReady);
+            if(!dataReady && i == 0){
+                uint16_t startTime = millis();
+                LOG(F("No data available on iteration 0, waiting an additional 5 seconds to see if data becomes available"));
+                while(!dataReady && millis() < startTime + 5000){
+                    sen5x.readDataReady(dataReady);
+                }
+            }
+
+            if(dataReady)
+                sen5x.readMeasuredPmValues(Pm1p0, Pm2p5, Pm4p0, Pm10p0, numPm0p5, numPm1p0,
+                                        numPm2p5, numPm4p0, numPm10p0, particleSize);
+            else{
+                failedReads++;
+            }
+
+            massConcentrationPm1p0 += Pm1p0;
+            massConcentrationPm2p5 += Pm2p5;
+            massConcentrationPm4p0 += Pm4p0;
+            massConcentrationPm10p0 += Pm10p0;
+            if(readNumVals){
+                numConcentrationPm0p5 += numPm0p5;
+                numConcentrationPm1p0 += numPm1p0;
+                numConcentrationPm2p5 += numPm2p5;
+                numConcentrationPm4p0 += numPm4p0;
+                numConcentrationPm10p0 += numPm10p0;
+                typicalParticleSize += particleSize;
+            }
+            delay(1);
+        }
+
+        if(failedReads < PM_AVERAGE_COUNT){
+            // Calculate the average of the values (excluding failed reads)
+            massConcentrationPm1p0 /= (PM_AVERAGE_COUNT - failedReads);
+            massConcentrationPm2p5 /= (PM_AVERAGE_COUNT - failedReads);
+            massConcentrationPm4p0 /= (PM_AVERAGE_COUNT - failedReads);
+            massConcentrationPm10p0 /= (PM_AVERAGE_COUNT - failedReads);;
+
+            if(readNumVals){
+                numConcentrationPm0p5 /= (PM_AVERAGE_COUNT - failedReads);;
+                numConcentrationPm1p0 /= (PM_AVERAGE_COUNT - failedReads);;
+                numConcentrationPm2p5 /= (PM_AVERAGE_COUNT - failedReads);;
+                numConcentrationPm4p0 /= (PM_AVERAGE_COUNT - failedReads);;
+                numConcentrationPm10p0 /= (PM_AVERAGE_COUNT - failedReads);;
+                typicalParticleSize /= (PM_AVERAGE_COUNT - failedReads);;
+            }
+        }
+
+        else{
+            ERROR("Failed to read any data from the sensor, values might be incorrect. If this persists, please check for errors...");
+        }
+
+        float tmp = 0.0;
+        readErr = sen5x.readMeasuredValues(
+                                            tmp, tmp, tmp, tmp,
+                                            ambientHumidity, ambientTemperature, vocIndex,
+                                            noxIndex
+                                        );
+
+        readErr = sen5x.startMeasurementWithoutPm();
+        delay(60);
+    }
+
+    else {
+        LOG("Beginning measurement without PM, waiting 10 seconds for sensor to stabilize...");
+        uint16_t readErr = sen5x.startMeasurementWithoutPm();
+        delay(10000);
+
+        uint16_t error = 0;
+        // Give the sensor time to prepare for measuring
+        bool dataReady = false;
+        uint16_t startTime = millis();
+        LOG(F("Waiting for data to be ready... If not ready in 10 seconds we will stop trying"));
+        while(!dataReady && millis() < startTime + 10000){
+            error = sen5x.readDataReady(dataReady);
+            if(error){
+                errorToString(error, sensorError, OUTPUT_SIZE);
+                snprintf(output, OUTPUT_SIZE, "Failed to check if data was ready to be read: %s", sensorError);
+                ERROR(output);
+            }
+        }
+
+        // If the data was not ready we don't want to update the sensor values
+        if(dataReady){
+            LOG("Device was ready to read a new sample!");
+            float tmp = 0.0;
+            // Request the measured values form the sensor
+            error = sen5x.readMeasuredValues(
+                                                tmp, tmp, tmp, tmp,
+                                                ambientHumidity, ambientTemperature, vocIndex,
+                                                noxIndex
+                                            );
+
+            // Check if we had an error reading the sensor values
+            if(error){
+                errorToString(error, sensorError, OUTPUT_SIZE);
+                snprintf(output, OUTPUT_SIZE, "Error occurred when reading measurement: %s", sensorError);
+                ERROR(output);
+                FUNCTION_END;
+                return;
+            }
+        }else{
+            ERROR("No new data was ready within the given time period.");
+        }
+    }
 
     /* TODO: Implement this once we know the raw integration works.
     // Get the current connection status
@@ -86,43 +190,9 @@ void Loom_SEN55::measure() {
     }*/
 
     /* Attempt to initiate a measurement with the sensor */
-
-    uint16_t error = 0;
-
-    // Give the sensor time to prepare for measuring
-    bool dataReady = false;
-    uint16_t startTime = millis();
-    LOG("Waiting for data to be ready... If not ready in 10 seconds we will stop trying");
-    while(!dataReady && millis() < startTime + 10000){
-        error = sen5x.readDataReady(dataReady);
-        if(error){
-            errorToString(error, sensorError, OUTPUT_SIZE);
-            snprintf(output, OUTPUT_SIZE, "Failed to check if data was ready to be read: %s", sensorError);
-            ERROR(output);
-        }
-    }
-
-    // If the data was not ready we don't want to update the sensor values
-    if(dataReady){
-        LOG("Device was ready to read a new sample!");
-        // Request the measured values form the sensor
-        error = sen5x.readMeasuredValues(
-                                            massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
-                                            massConcentrationPm10p0, ambientHumidity, ambientTemperature, vocIndex,
-                                            noxIndex
-                                        );
-
-        // Check if we had an error reading the sensor values
-        if(error){
-            errorToString(error, sensorError, OUTPUT_SIZE);
-            snprintf(output, OUTPUT_SIZE, "Error occurred when reading measurement: %s", sensorError);
-            ERROR(output);
-            FUNCTION_END;
-            return;
-        }
-    }else{
-        ERROR("No new data was ready within the given time period.");
-    }
+    
+    // Log Device status after measuring to check for errors
+    logDeviceStatus();
 
     FUNCTION_END;
 }
@@ -135,15 +205,25 @@ void Loom_SEN55::package() {
 
     // Only include the PM measurements if we are actually measuring PM
     if(measurePM){
-        json["PM1_0"] = massConcentrationPm10p0;
+        json["PM1_0"] = massConcentrationPm1p0;
         json["PM2_5"] = massConcentrationPm2p5;
         json["PM4_0"] = massConcentrationPm4p0;
         json["PM10_0"] = massConcentrationPm10p0;
+
+        if(readNumVals){
+            json["N_PM0_5"] = numConcentrationPm0p5;
+            json["N_PM1_0"] = numConcentrationPm1p0;
+            json["N_PM2_5"] = numConcentrationPm2p5;
+            json["N_PM4_0"] = numConcentrationPm4p0;
+            json["N_PM10_0"] = numConcentrationPm10p0;
+            json["Typical_Particle_Size"] = typicalParticleSize;
+        }
     }
     json["AmbientHumidity"] = (isnan(ambientHumidity) ? -1 : ambientHumidity);
     json["AmbientTemperature"] = (isnan(ambientTemperature) ? -1 : ambientTemperature);
     json["VocIndex"] = (isnan(vocIndex) ? -1 : vocIndex);
     json["NoxIndex"] = (isnan(noxIndex) ? -1 : noxIndex);
+
     FUNCTION_END;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -165,3 +245,52 @@ void Loom_SEN55::adjustTempOffset(float offset) {
     FUNCTION_END;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
+void Loom_SEN55::logDeviceStatus() {
+    FUNCTION_START;
+    char output[OUTPUT_SIZE];
+    char sensorError[OUTPUT_SIZE];
+
+    
+
+    uint32_t deviceStatus;
+
+    uint16_t error = sen5x.readDeviceStatus(deviceStatus);
+
+    std::bitset<32> bits(deviceStatus);
+
+    std::string bitString = bits.to_string();
+
+    snprintf(output, OUTPUT_SIZE, "Device Status: %s", bitString.c_str());
+    LOG(output);
+
+    if(error){
+            errorToString(error, sensorError, OUTPUT_SIZE);
+            snprintf(output, OUTPUT_SIZE, "Error occurred while logging device status: %s", sensorError);
+            ERROR(output);
+        }
+
+    FUNCTION_END;
+
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+void Loom_SEN55::resetValuesForMeasure() {
+    FUNCTION_START;
+    massConcentrationPm1p0 = 0;
+    massConcentrationPm2p5 = 0;
+    massConcentrationPm4p0 = 0;
+    massConcentrationPm10p0 = 0;
+    numConcentrationPm0p5 = 0;
+    numConcentrationPm1p0 = 0;
+    numConcentrationPm2p5 = 0;
+    numConcentrationPm4p0 = 0;
+    numConcentrationPm10p0 = 0;
+    typicalParticleSize = 0;
+    FUNCTION_END;
+    return;
+}

--- a/src/Sensors/I2C/Loom_SEN55/Loom_SEN55.h
+++ b/src/Sensors/I2C/Loom_SEN55/Loom_SEN55.h
@@ -2,47 +2,51 @@
 
 #include <SensirionI2CSen5x.h>
 #include <Wire.h>
+#include <bitset>
 
 #include "../I2CDevice.h"
 #include "Loom_Manager.h"
 
+#define PM_AVERAGE_COUNT 10     // Number of times to read the pm values then average them over
+
 /**
  *  SEN55 Air Quality sensors, supports pm 1.0, 2.5, 4.0, 10 as well as Temp/Humidity and Nox and Voc index
- * 
+ *
  * NOTE: To get accurate results using the SE555 it should be powered on and remain on as according to the data sheet,
  * the switch-on behavior for the VOC Index is ~ 1 hr and the NOx is ~ 6 hours.
  * Data sheet: https://cdn.sparkfun.com/assets/5/b/f/2/8/Sensirion_Datasheet_SEN5x.pdf (Page 8)
- * 
+ *
  *  @author Will Richards
- */ 
+ */
 class Loom_SEN55 : public I2CDevice{
     protected:
-       
+
        // Manager controlled functions
-        void measure() override;                               
-        void initialize() override;    
+        void measure() override;
+        void initialize() override;
         void power_up() override {};
-        void power_down() override {}; 
-        void package() override;   
+        void power_down() override {};
+        void package() override;
 
     public:
         /**
          * Constructs a new SEN55 sensor
-         * 
+         *
          * @param man Reference to the manager that is used to universally package all data
          * @param measurePM This sets whether or not we should conduct measurements without PM readings (uses less power)
          * @param useMux Whether or not we are using the multiplexer class
-         */ 
+         */
         Loom_SEN55(
                     Manager& man,
                     bool measurePM = true,
-                    bool useMux = false
+                    bool useMux = false,
+                    bool numMode = true
                 );
 
         /**
          * Adjust the temperature reading offset in celsius. By default it accounts for the internal heating of the sensor.
          * Adjustments should be made based off this datasheet: https://cdn.sos.sk/productdata/a8/47/608a6927/sen54-sdn-t.pdf
-         * 
+         *
          * @param offset The additional temperature offset in degrees celsius
         */
         void adjustTempOffset(float offset);
@@ -140,7 +144,7 @@ class Loom_SEN55 : public I2CDevice{
                                                 int16_t gainFactor) { return sen5x.setNoxAlgorithmTuningParameters(indexOffset, learningTimeOffsetHours, learningTimeGainHours, gatingMaxDurationMinutes, stdInitial, gainFactor); };
         /**
          * Get the PM 1.0 reading
-         */ 
+         */
         float getPM1() { return massConcentrationPm1p0; };
 
         /**
@@ -152,12 +156,12 @@ class Loom_SEN55 : public I2CDevice{
          * Get the PM4.0 reading
         */
         float getPM4() { return massConcentrationPm4p0; };
-        
+
         /**
          * Get the PM 10 reading
         */
         float getPM10() { return massConcentrationPm10p0; };
-        
+
         /**
          * Get the PM2.5 reading
         */
@@ -165,12 +169,12 @@ class Loom_SEN55 : public I2CDevice{
 
         /**
          * Get the temperature reading
-         */ 
+         */
         float getTemperature() { return ambientTemperature; };
 
         /**
          * Get the VOX Index reading
-         */ 
+         */
         float getVOCIndex() { return vocIndex; };
 
         /**
@@ -178,11 +182,23 @@ class Loom_SEN55 : public I2CDevice{
         */
         float getNOXIndex() { return noxIndex; };
 
+        /**
+         * Logs device register status 
+        */
+       void logDeviceStatus();
+
+        /**
+        * Reset relevant values to 0, this is useful for preparing for another measurement cycle.
+        * @return An array of the values pre-reset
+        */
+        void resetValuesForMeasure();
+
     private:
         Manager* manInst;                           // Instance of the manager
         SensirionI2CSen5x sen5x;                    // Instance of the SEN55 object
 
         bool measurePM;                             // Are we measuring particulate matter or not
+        bool readNumVals;                           // Do we want to read the number concentration and typical particle size?
 
         /* Sensor readings */
         float massConcentrationPm1p0;
@@ -193,6 +209,15 @@ class Loom_SEN55 : public I2CDevice{
         float ambientTemperature;
         float vocIndex;
         float noxIndex;
+        /* PM number readings */
+        float numConcentrationPm0p5;
+        float numConcentrationPm1p0;
+        float numConcentrationPm2p5;
+        float numConcentrationPm4p0;
+        float numConcentrationPm10p0;
+        float typicalParticleSize;
 
-       
+        int pmReadFrequency = 0;                   // Counter for the number of times we have read the PM values
+
+
 };


### PR DESCRIPTION
This SEN55 change is necessary for sensor operation within the Wisp project. Without it the SEN55 PM, VOC and NOx measurement behavior is unpredictable and sometimes prints out all zero values due to insufficient warm up time. The changes within the Hypnos are an artifact of the merge and can be disregarded. Since they weren't code breaking or noticeable I didn't bother going back in the code to fix them. If this is needed let me know and I can revisit. 