### PR TITLE
Fixed tempdoc size and MongoDB credentials 

### DIFF
--- a/src/Internet/Logging/Loom_MongoDB/Loom_MongoDB.cpp
+++ b/src/Internet/Logging/Loom_MongoDB/Loom_MongoDB.cpp
@@ -225,34 +225,23 @@ void Loom_MongoDB::loadConfigFromJSON(char* json){
     port = 0;
     
     /* We should check if any parameter is null */
-    if(!doc["broker"].isNull())
+    if(!doc["broker"].isNull() && !doc["database"].isNull() && !doc["username"].isNull() && !doc["password"].isNull() &&
+    !doc["project"].isNull() && !doc["port"].isNull() && strlen(projectServer) > 0){
         strncpy(address, doc["broker"].as<const char*>(), 100);
-
-    if(!doc["database"].isNull())
         strncpy(database_name, doc["database"].as<const char*>(), 100);
-    
-    if(!doc["username"].isNull())
         strncpy(username, doc["username"].as<const char*>(), 100);
-
-    if(!doc["password"].isNull())
         strncpy(password, doc["password"].as<const char*>(), 100);
-
-    if(!doc["project"].isNull())
         strncpy(projectServer, doc["project"].as<const char*>(), 100);
-
-    if(!doc["port"].isNull())
         port = doc["port"].as<int>();
-   
-    if(strlen(projectServer) > 0){
-        // Formulate a topic to publish on with the format "ProjectName/DatabaseName/DeviceNameInstanceNumber" eg. WeatherChimes/Chimes/Chime1
         snprintf_P(topic, MAX_TOPIC_LENGTH, PSTR("%s/%s/%s%i"), projectServer, database_name, manInst->get_device_name(), manInst->get_instance_num());
+        moduleInitialized = true;
     }
     else{
         // Formulate a topic to publish on with the format "DatabaseName/DeviceNameInstanceNumber" eg. WeatherChimes/Chime1
         snprintf_P(topic, MAX_TOPIC_LENGTH, PSTR("%s/%s%i"), database_name, manInst->get_device_name(), manInst->get_instance_num());
+        moduleInitialized = false; 
     }
     
-    moduleInitialized = true;
     free(json);
     FUNCTION_END;
 }

--- a/src/Internet/Logging/Loom_MongoDB/Loom_MongoDB.cpp
+++ b/src/Internet/Logging/Loom_MongoDB/Loom_MongoDB.cpp
@@ -202,7 +202,7 @@ bool Loom_MongoDB::publish(Loom_BatchSD& batchSD){
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-void Loom_MongoDB::loadConfigFromJSON(char* json){
+bool Loom_MongoDB::loadConfigFromJSON(char* json){
     FUNCTION_START;
     char output[OUTPUT_SIZE];
     char topic[MAX_TOPIC_LENGTH];
@@ -225,8 +225,12 @@ void Loom_MongoDB::loadConfigFromJSON(char* json){
     port = 0;
     
     /* We should check if any parameter is null */
-    if(!doc["broker"].isNull() && !doc["database"].isNull() && !doc["username"].isNull() && !doc["password"].isNull() &&
-    !doc["project"].isNull() && !doc["port"].isNull() && strlen(projectServer) > 0){
+    if(!doc["broker"].isNull() && 
+    !doc["database"].isNull() && 
+    !doc["username"].isNull() && 
+    !doc["password"].isNull() && 
+    !doc["port"].isNull() && 
+    strlen(projectServer) > 0){
         strncpy(address, doc["broker"].as<const char*>(), 100);
         strncpy(database_name, doc["database"].as<const char*>(), 100);
         strncpy(username, doc["username"].as<const char*>(), 100);
@@ -235,14 +239,19 @@ void Loom_MongoDB::loadConfigFromJSON(char* json){
         port = doc["port"].as<int>();
         snprintf_P(topic, MAX_TOPIC_LENGTH, PSTR("%s/%s/%s%i"), projectServer, database_name, manInst->get_device_name(), manInst->get_instance_num());
         moduleInitialized = true;
+        free(json);
+        FUNCTION_END;
+        return true;
     }
     else{
         // Formulate a topic to publish on with the format "DatabaseName/DeviceNameInstanceNumber" eg. WeatherChimes/Chime1
         snprintf_P(topic, MAX_TOPIC_LENGTH, PSTR("%s/%s%i"), database_name, manInst->get_device_name(), manInst->get_instance_num());
         moduleInitialized = false; 
+        free(json);
+        FUNCTION_END;
+        return false;
     }
     
-    free(json);
-    FUNCTION_END;
+    
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Radio/Loom_LoRa/Loom_LoRa.cpp
+++ b/src/Radio/Loom_LoRa/Loom_LoRa.cpp
@@ -193,10 +193,11 @@ FragReceiveStatus Loom_LoRa::receiveFrag(uint timeout, bool shouldProxy,
 
     LOGF("Received packet from %i", *fromAddress);
 
-    StaticJsonDocument<300> tempDoc;
+    //510 is our expected maximum size
+    StaticJsonDocument<510> tempDoc;
 
     // cast buf to const to avoid mutation
-    auto err = deserializeMsgPack(tempDoc, (const char *)buf, sizeof(buf));
+    auto err = deserializeMsgPack(tempDoc, buf, sizeof(buf));
     if (err != DeserializationError::Ok) {
         ERRORF("Error occurred parsing MsgPack: %s", err.c_str());
         return FragReceiveStatus::Error;


### PR DESCRIPTION
Lora tempdoc size wasn't big enough to deserialize, leading to memory issues.

MongoDB settings were set non transactionally, meaning they would be set even if there was a failure. It also wrongly enabled the module. 