### PR TITLE
Fix incorrect MAX31856 constructor parameters

### DIFF
--- a/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.h
+++ b/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31856.h
@@ -25,13 +25,13 @@ class Loom_MAX31856 : public Module{
         /**
          * Construct a new sensor class
          * @param man Reference to the manager
-         * @param chip_select What pin SPI pin to use
          * @param num_samples The number of samples to collect and average
+         * @param chip_select What pin SPI pin to use
          * @param mosi
          * @param miso
          * @param sclk
          */ 
-        Loom_MAX31856(Manager& man, int chip_select = 10, int samples = 1, int mosi = 11, int miso = 12, int sclk = 13 );
+        Loom_MAX31856(Manager& man, int samples = 1, int chip_select = 10, int mosi = 11, int miso = 12, int sclk = 13 );
 
         /**
          * Get the recorded temperature


### PR DESCRIPTION
The "_samples_" and "_chip_select_" default parameters were swapped in the header declaration. The Loom_MAX31856 module was not functional without overriding the default values before this change.