### PR TITLE
Hypnos sleep fix

### DIFF
--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -459,7 +459,7 @@ void Loom_Hypnos::setInterruptDuration(const TimeSpan duration){
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 void Loom_Hypnos::sleep(bool waitForSerial){
-    // Try to power down the active modules
+	
     // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one, we need to check if we have powered on already so we dont use the RTC that isn't enabled
     bool hasAlarmTriggered = false;
 	

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -460,6 +460,10 @@ void Loom_Hypnos::setInterruptDuration(const TimeSpan duration){
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 void Loom_Hypnos::sleep(bool waitForSerial){
     // Try to power down the active modules
+    // If the alarm set time is less than the current time we missed our next alarm so we need to set a new one, we need to check if we have powered on already so we dont use the RTC that isn't enabled
+    bool hasAlarmTriggered = false;
+	
+	// Try to power down the active modules
     if (shouldPowerUp) {
         manInst->power_down();
 


### PR DESCRIPTION
Sketches using 4.8.0 main branch would not compile because hasAlarmTriggered was not defined in the module. I referenced wisp-dev to see where this was normally set. Adding this change fixed errors. 