### PR TITLE
Fix LTE UTC timezone bug

### DIFF
--- a/src/Internet/Connectivity/Loom_LTE/Loom_LTE.cpp
+++ b/src/Internet/Connectivity/Loom_LTE/Loom_LTE.cpp
@@ -334,6 +334,8 @@ bool Loom_LTE::getNetworkTime(int* year, int* month, int* day, int* hour, int* m
 
     // Pull the current values from the GSM
     if(!modem.getNetworkTime(year, month, day, hour, minute, second, tz)){
+        // Reset original timezone value.
+        *tz = timezone;
         return false;
     }
 
@@ -350,7 +352,6 @@ bool Loom_LTE::getNetworkTime(int* year, int* month, int* day, int* hour, int* m
 
     // Reset original timezone value.
     *tz = timezone;
-
     return true;
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/Internet/Connectivity/Loom_LTE/Loom_LTE.cpp
+++ b/src/Internet/Connectivity/Loom_LTE/Loom_LTE.cpp
@@ -340,7 +340,7 @@ bool Loom_LTE::getNetworkTime(int* year, int* month, int* day, int* hour, int* m
     }
 
     // Create a DateTime object from GSM UTC time and then add the 
-    // timezone to the 
+    // timezone to the value to get adjusted local time.
     DateTime utcTime = DateTime(*year, *month, *day, *hour, *minute, *second);
     DateTime localTime = utcTime + TimeSpan(0, (int)timezone, 0, 0);
     *year = localTime.year();


### PR DESCRIPTION
In reference to #193.

## Fix

The TinyGsm `modem.getNetworkTime` function accepts variable references `(year, month, day, hour, minute, second, timezone)` and then overwrites their values with the network time **defaulting to UTC**. In effect, the TinyGsm `modem.getNetworkTime` function would overwrite the referenced timezone (the timezone supplied when constructing the hypnos object) with the UTC value.

Here is the code in TinyGSM [getNetworkTimeImpl](https://github.com/vshymanskyy/TinyGSM/blob/f412f93745fd53624110a38ccbdc3e8c300a4ba8/src/TinyGsmTime.tpp#L153) that overwrites the timezone:

```
if (timezone != nullptr) *timezone = static_cast<float>(itimezone) / 4.0;
```

The fix was to save the user-defined timezone value into a local variable before calling `modem.getNetworkTime` and then reassign that value to the referenced `int* tz` before returning from the function.

## Demo

I tested this by creating an ino based on [examples/Hypnos/Hypnos_NTP_Sync
](https://github.com/OPEnSLab-OSU/Loom-V4/blob/main/examples/Hypnos/Hypnos_NTP_Sync/Hypnos_NTP_Sync.ino).

```
#include <Loom_Manager.h>
#include <Hardware/Loom_Hypnos/Loom_Hypnos.h>
#include <Internet/Connectivity/Loom_LTE/Loom_LTE.h>

Manager manager("Device", 1);
Loom_Hypnos hypnos(manager, HYPNOS_VERSION::V3_3, TIME_ZONE::PST, false, false);
Loom_LTE lte(manager, "hologram", "", "");

void isrTrigger()
{
  hypnos.wakeup();
}

void setup() {
  manager.beginSerial();
  hypnos.setWakeConfiguration(POWERRAIL_CONFIG::PR_3V_ON_5V_ON);
  hypnos.setSleepConfiguration(POWERRAIL_CONFIG::PR_3V_OFF_5V_ON);

  hypnos.enable();
  hypnos.setNetworkInterface(&lte);

  manager.initialize();

  hypnos.registerInterrupt(isrTrigger);
  hypnos.networkTimeUpdate();
}

void loop() {}
```

Here is the serial monitor output when running `hypnos.networkTimeUpdate()` before and after the bug fix:

Before (UTC):

```
19:23:26.437 -> [DEBUG] [:networkTimeUpdate:335] Network time successfully set to: 2026.01.16 11:23:26
```

After (PST):

```
19:25:19.892 -> [DEBUG] [:networkTimeUpdate:335] Network time successfully set to: 2026.01.15 19:25:19
```