### PR TITLE
fix: correct AS7263 example type name

### DIFF
--- a/examples/Sensors/I2C/AS7263/AS7263.ino
+++ b/examples/Sensors/I2C/AS7263/AS7263.ino
@@ -11,9 +11,9 @@
 
 Manager manager("Device", 1);
 
-// Reads the battery voltage
-// Manger Instance,      useMux Address, Gain, Mode, Integration Time
-Loom_AwS7262 as63(manager, false, 0x49,    1,    3,    50);
+// Reads the sensor values
+// Manager instance,      useMux Address, Gain, Mode, Integration Time
+Loom_AS7263 as63(manager, false, 0x49,    1,    3,    50);
 
 void setup() {
 


### PR DESCRIPTION
## Summary\n- fix the example sensor type from `Loom_AwS7262` to `Loom_AS7263`\n- align the nearby comments with what the example actually does\n\n## Validation\n- verified the broken `Loom_AwS7262` symbol no longer appears in the example\n- verified the example now instantiates `Loom_AS7263`\n\nCloses #290