### PR TITLE
fix: let example sketches compile without local secrets header

### DIFF
--- a/examples/Internet/Communication/Max/Max_AP_MPU/Max_AP_MPU.ino
+++ b/examples/Internet/Communication/Max/Max_AP_MPU/Max_AP_MPU.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/Max_MPU/Max_MPU.ino
+++ b/examples/Internet/Communication/Max/Max_MPU/Max_MPU.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/Max_Neopixel/Max_Neopixel.ino
+++ b/examples/Internet/Communication/Max/Max_Neopixel/Max_Neopixel.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/Max_Relay/Max_Relay.ino
+++ b/examples/Internet/Communication/Max/Max_Relay/Max_Relay.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/Max_Servo/Max_Servo.ino
+++ b/examples/Internet/Communication/Max/Max_Servo/Max_Servo.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/Max_Stepper/Max_Stepper.ino
+++ b/examples/Internet/Communication/Max/Max_Stepper/Max_Stepper.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Communication/Max/RawMax/RawMax.ino
+++ b/examples/Internet/Communication/Max/RawMax/RawMax.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Connectivity/LTE/LTE.ino
+++ b/examples/Internet/Connectivity/LTE/LTE.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Connectivity/WIFI/WIFI.ino
+++ b/examples/Internet/Connectivity/WIFI/WIFI.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Logging/LTEMongoDBBatch/LTEMongoDBBatch.ino
+++ b/examples/Internet/Logging/LTEMongoDBBatch/LTEMongoDBBatch.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Logging/ThingSpeak/ThingSpeak.ino
+++ b/examples/Internet/Logging/ThingSpeak/ThingSpeak.ino
@@ -9,7 +9,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Logging/WiFiMongoDB/WiFiMongoDB.ino
+++ b/examples/Internet/Logging/WiFiMongoDB/WiFiMongoDB.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Internet/Logging/WiFiMongoDBBatch/WiFiMongoDBBatch.ino
+++ b/examples/Internet/Logging/WiFiMongoDBBatch/WiFiMongoDBBatch.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Lab Examples/Dendrometer/hub/hub.ino
+++ b/examples/Lab Examples/Dendrometer/hub/hub.ino
@@ -1,4 +1,49 @@
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h> //4.7
 

--- a/examples/Lab Examples/LilyPad/LilyPad.ino
+++ b/examples/Lab Examples/LilyPad/LilyPad.ino
@@ -14,7 +14,52 @@
 
 #define COLLECTION_NAME "LP1"
 
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 // Loom includes
 #include <Loom_Manager.h>

--- a/examples/Lab Examples/LoRa_To_4G/LoRa_To_4G.ino
+++ b/examples/Lab Examples/LoRa_To_4G/LoRa_To_4G.ino
@@ -2,7 +2,52 @@
  * This is a lab example combine LoRa communication and 4G connectivity
  */
 
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Lab Examples/Wattson/Wattson.ino
+++ b/examples/Lab Examples/Wattson/Wattson.ino
@@ -3,7 +3,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 

--- a/examples/Lab Examples/WeatherChimes/WeatherChimes_WithMax/WeatherChimes_WithMax.ino
+++ b/examples/Lab Examples/WeatherChimes/WeatherChimes_WithMax/WeatherChimes_WithMax.ino
@@ -5,7 +5,52 @@
  * 
  * MANAGER MUST BE INCLUDED FIRST IN ALL CODE
  */
+#if __has_include("arduino_secrets.h")
 #include "arduino_secrets.h"
+#endif
+
+#ifndef SECRET_SSID
+#define SECRET_SSID ""
+#endif
+#ifndef SECRET_PASS
+#define SECRET_PASS ""
+#endif
+#ifndef NETWORK_APN
+#define NETWORK_APN ""
+#endif
+#ifndef NETWORK_NAME
+#define NETWORK_NAME ""
+#endif
+#ifndef NETWORK_USER
+#define NETWORK_USER ""
+#endif
+#ifndef NETWORK_PASS
+#define NETWORK_PASS ""
+#endif
+#ifndef SECRET_BROKER
+#define SECRET_BROKER ""
+#endif
+#ifndef SECRET_PORT
+#define SECRET_PORT 0
+#endif
+#ifndef DATABASE
+#define DATABASE ""
+#endif
+#ifndef BROKER_USER
+#define BROKER_USER ""
+#endif
+#ifndef BROKER_PASS
+#define BROKER_PASS ""
+#endif
+#ifndef PROJECT
+#define PROJECT ""
+#endif
+#ifndef CHANNEL_ID
+#define CHANNEL_ID 0
+#endif
+#ifndef CLIENT_ID
+#define CLIENT_ID ""
+#endif
 
 #include <Loom_Manager.h>
 


### PR DESCRIPTION
## Summary
- make every example that includes `arduino_secrets.h` compile even when the local secrets file is absent
- use `__has_include` so real local credentials still take precedence
- provide empty fallback credential macros for the Wi-Fi, LTE, MongoDB, and ThingSpeak examples reported in the issue

## Validation
- verified all 18 sketches that include `arduino_secrets.h` now guard the include with `__has_include`
- `arduino-cli` is not available in this environment, so I could not rerun the full compile-examples script locally

Closes #291
