### PR TITLE
Bugfix/sd eod check

### DIFF
--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -11,7 +11,7 @@ SDManager::SDManager(Manager *man, int sd_chip_select)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::writeLineToFile(const char *filename, const char *content) {
-
+    
     // Check if the SD card is actually functional
     if (sdInitialized) {
         // Open the given file for writing
@@ -80,20 +80,18 @@ void SDManager::writeHeaders() {
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
+// Check if EOD reached, use currentTime from SDmanager log()
+// int Day, track day num, then file.close(), then file = sd.open, Day = currentTime.day() to update Day
 bool SDManager::log(DateTime currentTime) {
     char output[MAX_JSON_SIZE + 1];
 
     if (sdInitialized) {
 
-        // Open the file in read/write mode, create the file if we need to and append the content to
-        // the end of the file
-        myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
-
         if (myFile) {
 
             // If this file has never been written to before we need to create and write the proper
             // headers to the file
-            if (myFile.available() <= 3) {
+            if (myFile.size() <= 3) {
                 // Set the date created timestamp of the File
                 myFile.timestamp(T_CREATE, currentTime.year(), currentTime.month(),
                                  currentTime.day(), currentTime.hour(), currentTime.minute(),
@@ -157,12 +155,18 @@ bool SDManager::log(DateTime currentTime) {
             // Write the matching data into the CSV file
             myFile.println(output);
 
-            // Set the last modified date
-            myFile.timestamp(T_WRITE, currentTime.year(), currentTime.month(), currentTime.day(),
-                             currentTime.hour(), currentTime.minute(), currentTime.second());
+            // // Set the last modified date
+            // myFile.timestamp(T_WRITE, currentTime.year(), currentTime.month(), currentTime.day(),
+            //                  currentTime.hour(), currentTime.minute(), currentTime.second());
 
-            // Close the file
-            myFile.close();
+            // Sync file, don't close unless EOD
+            myFile.sync();
+
+            if(currentTime.day() != lastClosed){
+                myFile.close();
+                myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                lastClosed = currentTime.day();
+            }
 
             // Inform the user that we have successfully written to the file
             snprintf_P(output, MAX_JSON_SIZE, PSTR("Successfully logged data to %s"), fileName);
@@ -227,6 +231,9 @@ bool SDManager::begin() {
             return false;
         }
         updateCurrentFileName();
+        // Open the file in read/write mode, create the file if we need to and append the content to
+        // the end of the file
+        myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
     }
 
     // Once the SD card has initialized the first round through we don't want to update the file
@@ -331,16 +338,16 @@ void SDManager::logBatch() {
     // We want to clear the file after the batch size has been exceeded
     if (current_batch >= batch_size) {
         current_batch = 0;
-        myFile = sd.open(f_name, O_WRITE | O_TRUNC | O_APPEND);
+        batchFile = sd.open(f_name, O_WRITE | O_TRUNC | O_APPEND);
     } else {
-        myFile = sd.open(f_name, O_WRITE | O_CREAT | O_APPEND);
+        batchFile = sd.open(f_name, O_WRITE | O_CREAT | O_APPEND);
     }
     // Check if the file has been opened properly and write the JSON packet to one line
-    if (myFile) {
+    if (batchFile) {
 
         manInst->getJSONString(jsonString);
-        myFile.println(jsonString);
-        myFile.close();
+        batchFile.println(jsonString);
+        batchFile.close();
         current_batch++;
 
     } else {

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -105,9 +105,6 @@ bool SDManager::log(DateTime currentTime) {
             snprintf_P(output, MAX_JSON_SIZE, PSTR("%s,%i,"), manInst->get_device_name(),
                        manInst->get_instance_num());
 
-            // Write the Instance data that isn't included in the JSON packet
-            myFile.print(output);
-            memset(output, '\0', MAX_JSON_SIZE); // Clear array
 
             JsonObject document = manInst->getDocument().as<JsonObject>();
 
@@ -160,9 +157,23 @@ bool SDManager::log(DateTime currentTime) {
                 checksum += (uint8_t)output[i];
             }
 
+            // LEAVE IN FOR TESTING TO ENTER VERIFY CHECKSUM BELOW
+            checksum++;
+            // REMOVE LATER
+
+            // TESTING CHECKSUM VALUE AND CSV LINE HERE TO COMPARE TO VERIFY CHECKSUM BELOW
+            char buf[64];
+            snprintf(buf, 64, "log Checksum: %i", checksum);
+            printModuleName(buf);
+
+            char buff[MAX_JSON_SIZE + 32];
+            snprintf(buff, MAX_JSON_SIZE + 32, "LOG OUTPUT BEFORE APPEND: %s", output);
+            printModuleName(buff);
+            ///////////////////////////////////////////////////////////////////////////
+
             // Append checksum value to end of line, last column 
             char checksumString[8];
-            snprintf(checksumString, 8, "%u,", checksum);
+            snprintf(checksumString, 8, ",%u", checksum);
             strncat(output, checksumString, MAX_JSON_SIZE);
 
             // Write the matching data into the CSV file
@@ -171,9 +182,14 @@ bool SDManager::log(DateTime currentTime) {
             // Sync/flush file, don't close unless EOD
             myFile.sync();
 
+            // LEAVE IN FOR TESTING TO ENTER IF BELOW
+            lastClosed++;
+            /////////////////////////////////////////
+
             // Checks if the day has chenged, if so we enter and will close, reopen file
             if(currentTime.day() != lastClosed){
                 // Run the checksum by going through the file
+                LOG(F("End of day detected, verifying checksum"));
                 // If passes verification, close and reopen file
                 if(verifyChecksum(myFile)){
                     myFile.close();
@@ -183,8 +199,12 @@ bool SDManager::log(DateTime currentTime) {
                 else{
                     myFile.close();
                     // open new file
-                    updateCurrentFileName();
-                    myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                    if(root.open("/", O_RDONLY)){
+                        updateCurrentFileName();
+                        myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                    } else {
+                        ERROR(F("Failed to open root for file rotation"));
+                    }
                 }
                 // Update day integer to current time so don't close file until end of next day
                 lastClosed = currentTime.day();
@@ -208,9 +228,10 @@ bool SDManager::log(DateTime currentTime) {
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// NEEDS TESTING, what if file is too big to parse through for feather board?
+// NEEDS TESTING
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-bool SDManager::verifyChecksum(File myFile){
+bool SDManager::verifyChecksum(File& myFile){
+    myFile.seekSet(0);
     char lineBuf[MAX_JSON_SIZE];
     int lineIndex = 0;
     int lineCount = 0;
@@ -229,7 +250,7 @@ bool SDManager::verifyChecksum(File myFile){
             lineCount++;
 
             // Skip headers in csv
-            if(lineCount > 3){
+            if(lineCount > 4){
                 if(checksumComma != nullptr){
                     // Get the value to compare to
                     uint16_t actualChecksum = atoi(checksumComma + 1);
@@ -242,11 +263,21 @@ bool SDManager::verifyChecksum(File myFile){
                         lineChecksum += (uint8_t)lineBuf[i];
                     }
 
+                    // FOR TESTING PURPOSES TO COMPARE CHECKSUM VALUES AND LINE OUTPUTS
+                    char buf[64];
+                    snprintf(buf, 64, "checksum from csv: %i, computed checksum: %i", actualChecksum, lineChecksum);
+                    printModuleName(buf);
+
+                    char buff[MAX_JSON_SIZE + 32];
+                    snprintf(buff, MAX_JSON_SIZE + 32, "VERIFY LINE OUTPUT: %s", lineBuf);
+                    printModuleName(buff);
+                    ///////////////////////////////////////////////////////////////////////////
+
                     // Compare actual checksum to computed checksum, if fails then file is corrupted
                     if(actualChecksum != lineChecksum){
-                        char buf[64];
+                        // char buf[64];
                         snprintf(buf, 64, "Error: Checksum Failed at Line %i", lineCount);
-                        printModuleName(buf);
+                        ERROR(buf);
                         return false;
                     }
                 }
@@ -264,7 +295,7 @@ bool SDManager::verifyChecksum(File myFile){
     printModuleName("Checksum Passed");
     return true;
 }
-
+//////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::begin() {

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -73,14 +73,14 @@ void SDManager::writeHeaders() {
         }
     }
 
+    strncat(header2, "checksum,", 512);
+
     // Write the headers to the file
     myFile.println(header1);
     myFile.println(header2);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-// Check if EOD reached, use currentTime from SDmanager log()
-// int Day, track day num, then file.close(), then file = sd.open, Day = currentTime.day() to update Day
 bool SDManager::log(DateTime currentTime) {
     char output[MAX_JSON_SIZE + 1];
 
@@ -152,6 +152,17 @@ bool SDManager::log(DateTime currentTime) {
                 }
             }
 
+            // Compute checksum for line
+            uint16_t checksum = 0;
+            for(int i = 0; i < strlen(output); i++){
+                checksum += (uint8_t)output[i];
+            }
+
+            // Append to line
+            char checksumString[8];
+            snprintf(checksumString, 8, "%u,", checksum);
+            strncat(output, checksumString, MAX_JSON_SIZE);
+
             // Write the matching data into the CSV file
             myFile.println(output);
 
@@ -159,8 +170,16 @@ bool SDManager::log(DateTime currentTime) {
             myFile.sync();
 
             if(currentTime.day() != lastClosed){
-                myFile.close();
-                myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                if(verifyChecksum(myFile)){
+                    myFile.close();
+                    myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                }
+                else{
+                    myFile.close();
+                    // open new file
+                    updateCurrentFileName();
+                    myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
+                }
                 lastClosed = currentTime.day();
             }
 
@@ -181,6 +200,52 @@ bool SDManager::log(DateTime currentTime) {
     }
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool SDManager::verifyChecksum(File myFile){
+    char lineBuf[MAX_JSON_SIZE];
+    int lineIndex = 0;
+    int lineCount = 0;
+    
+    while(myFile.available()){
+        char c = myFile.read();
+
+        if(c == '\n'){
+            lineBuf[lineIndex] = '\0';
+
+            char* checksumComma = strrchr(lineBuf, ',');
+
+            lineCount++;
+
+            // Skip headers in csv
+            if(lineCount > 3){
+                if(checksumComma != nullptr){
+                    uint16_t actualChecksum = atoi(checksumComma + 1);
+
+                    *checksumComma = '\0';
+
+                    uint16_t lineChecksum = 0;
+                    for(int i = 0; i < strlen(lineBuf); i++){
+                        lineChecksum += (uint8_t)lineBuf[i];
+                    }
+
+                    if(actualChecksum != lineChecksum){
+                        printModuleName("Error: Checksum Failed");
+                        return false;
+                    }
+                }
+            }
+            lineIndex = 0;
+            memset(lineBuf, '\0', MAX_JSON_SIZE);
+            
+        }
+        else{
+            lineBuf[lineIndex++] = c;
+        }
+    }    
+    printModuleName("Checksum Passed");
+    return true;
+}
+
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::begin() {

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -11,16 +11,15 @@ SDManager::SDManager(Manager *man, int sd_chip_select)
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::writeLineToFile(const char *filename, const char *content) {
-    
     // Check if the SD card is actually functional
     if (sdInitialized) {
         // Open the given file for writing
-        myFile = sd.open(filename, O_RDWR | O_CREAT | O_APPEND);
+        File tempFile = sd.open(filename, O_RDWR | O_CREAT | O_APPEND);
 
         // Check if the file was actually opened, if so write the content to the file
-        if (myFile) {
-            myFile.println(content);
-            myFile.close();
+        if (tempFile) {
+            tempFile.println(content);
+            tempFile.close();
             return true;
         }
         printModuleName("Failed to Open File!");
@@ -98,6 +97,7 @@ bool SDManager::log(DateTime currentTime) {
                                  currentTime.second());
 
                 writeHeaders();
+                lastClosed = currentTime.day();
             }
 
             snprintf_P(output, MAX_JSON_SIZE, PSTR("%s,%i,"), manInst->get_device_name(),
@@ -155,10 +155,6 @@ bool SDManager::log(DateTime currentTime) {
             // Write the matching data into the CSV file
             myFile.println(output);
 
-            // // Set the last modified date
-            // myFile.timestamp(T_WRITE, currentTime.year(), currentTime.month(), currentTime.day(),
-            //                  currentTime.hour(), currentTime.minute(), currentTime.second());
-
             // Sync file, don't close unless EOD
             myFile.sync();
 
@@ -178,8 +174,8 @@ bool SDManager::log(DateTime currentTime) {
 
         // If we want to log batch data do so
         if (batch_size > 0)
-            logBatch();
-
+            logBatch();   
+            
     } else {
         printModuleName("Failed to log! SD card not Initialized!");
     }
@@ -231,8 +227,10 @@ bool SDManager::begin() {
             return false;
         }
         updateCurrentFileName();
+
         // Open the file in read/write mode, create the file if we need to and append the content to
         // the end of the file
+        // Don't want it to open every time hypnos wakes up, will overwrite persistent handle
         myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
     }
 
@@ -310,16 +308,16 @@ char *SDManager::readFile(const char *fileName) {
 
     long index = 0;
     if (sdInitialized) {
-        myFile = sd.open(fileName);
+        File tempFile = sd.open(fileName);
 
-        if (myFile) {
+        if (tempFile) {
             // read from the file until there's nothing else in it:
-            while (myFile.available()) {
-                fileContents[index] = (char)(myFile.read());
+            while (tempFile.available()) {
+                fileContents[index] = (char)(tempFile.read());
                 index++;
             }
             fileContents[index] = '\0';
-            myFile.close();
+            tempFile.close();
         } else {
             printModuleName("Failed to open file!");
         }

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -105,7 +105,6 @@ bool SDManager::log(DateTime currentTime) {
             snprintf_P(output, MAX_JSON_SIZE, PSTR("%s,%i,"), manInst->get_device_name(),
                        manInst->get_instance_num());
 
-
             JsonObject document = manInst->getDocument().as<JsonObject>();
 
             // If there is a key that contains timestamp data when need to include that separately
@@ -153,11 +152,11 @@ bool SDManager::log(DateTime currentTime) {
 
             // Compute checksum for line for later checking
             uint16_t checksum = 0;
-            for(int i = 0; i < strlen(output); i++){
+            for (int i = 0; i < strlen(output); i++) {
                 checksum += (uint8_t)output[i];
             }
 
-            // Append checksum value to end of line, last column 
+            // Append checksum value to end of line, last column
             char checksumString[8];
             snprintf(checksumString, 8, ",%u", checksum);
             strncat(output, checksumString, MAX_JSON_SIZE);
@@ -169,19 +168,19 @@ bool SDManager::log(DateTime currentTime) {
             myFile.sync();
 
             // Checks if the day has chenged, if so we enter and will close, reopen file
-            if(currentTime.day() != lastClosed){
+            if (currentTime.day() != lastClosed) {
                 // Run the checksum by going through the file
                 LOG(F("End of day detected, verifying checksum"));
                 // If passes verification, close and reopen file
-                if(verifyChecksum(myFile)){
+                if (verifyChecksum(myFile)) {
                     myFile.close();
                     myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
                 }
                 // If failed verification, open new file
-                else{
+                else {
                     myFile.close();
                     // open new file
-                    if(root.open("/", O_RDONLY)){
+                    if (root.open("/", O_RDONLY)) {
                         updateCurrentFileName();
                         myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
                     } else {
@@ -202,8 +201,8 @@ bool SDManager::log(DateTime currentTime) {
 
         // If we want to log batch data do so
         if (batch_size > 0)
-            logBatch();   
-            
+            logBatch();
+
     } else {
         printModuleName("Failed to log! SD card not Initialized!");
     }
@@ -211,28 +210,29 @@ bool SDManager::log(DateTime currentTime) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-bool SDManager::verifyChecksum(File& myFile){
+bool SDManager::verifyChecksum(File &myFile) {
     myFile.seekSet(0);
     char lineBuf[MAX_JSON_SIZE];
     int lineIndex = 0;
     int lineCount = 0;
-    
-    while(myFile.available()){
+
+    while (myFile.available()) {
         // Go through every char in file
         char c = myFile.read();
 
         // When we hit a new line, we start evaluating
-        if(c == '\n'){
+        if (c == '\n') {
             lineBuf[lineIndex] = '\0';
 
-            // Find last comma = checksum, don't evaluate on the checksum number since it is point of reference
-            char* checksumComma = strrchr(lineBuf, ',');
+            // Find last comma = checksum, don't evaluate on the checksum number since it is point
+            // of reference
+            char *checksumComma = strrchr(lineBuf, ',');
 
             lineCount++;
 
             // Skip headers in csv
-            if(lineCount > 4){
-                if(checksumComma != nullptr){
+            if (lineCount > 4) {
+                if (checksumComma != nullptr) {
                     // Get the value to compare to
                     uint16_t actualChecksum = atoi(checksumComma + 1);
 
@@ -240,12 +240,12 @@ bool SDManager::verifyChecksum(File& myFile){
 
                     // Go through the lineBuf (one line in csv) and manually add checksum
                     uint16_t lineChecksum = 0;
-                    for(int i = 0; i < strlen(lineBuf); i++){
+                    for (int i = 0; i < strlen(lineBuf); i++) {
                         lineChecksum += (uint8_t)lineBuf[i];
                     }
 
                     // Compare actual checksum to computed checksum, if fails then file is corrupted
-                    if(actualChecksum != lineChecksum){
+                    if (actualChecksum != lineChecksum) {
                         char buf[64];
                         snprintf(buf, 64, "Error: Checksum Failed at Line %i", lineCount);
                         ERROR(buf);
@@ -257,11 +257,12 @@ bool SDManager::verifyChecksum(File& myFile){
             lineIndex = 0;
             memset(lineBuf, '\0', MAX_JSON_SIZE);
         }
-        // When not at endline, just keep adding to lineBuf that will represent array of csv characters
-        else{
+        // When not at endline, just keep adding to lineBuf that will represent array of csv
+        // characters
+        else {
             lineBuf[lineIndex++] = c;
         }
-    }    
+    }
     // If verification passes, file is not corrupted
     printModuleName("Checksum Passed");
     return true;

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -220,6 +220,9 @@ bool SDManager::verifyChecksum(File &myFile) {
         // Go through every char in file
         char c = myFile.read();
 
+        // Never let WD timer reset while reading/verifying file
+        WD_TIMER_RESET; 
+
         // When we hit a new line, we start evaluating
         if (c == '\n') {
             lineBuf[lineIndex] = '\0';

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -86,10 +86,12 @@ bool SDManager::log(DateTime currentTime) {
 
     if (sdInitialized) {
 
+        // File should be opened already from begin or from previous log
         if (myFile) {
 
             // If this file has never been written to before we need to create and write the proper
             // headers to the file
+            // Dependent on file size because opening in O_APPEND mode
             if (myFile.size() <= 3) {
                 // Set the date created timestamp of the File
                 myFile.timestamp(T_CREATE, currentTime.year(), currentTime.month(),
@@ -152,13 +154,13 @@ bool SDManager::log(DateTime currentTime) {
                 }
             }
 
-            // Compute checksum for line
+            // Compute checksum for line for later checking
             uint16_t checksum = 0;
             for(int i = 0; i < strlen(output); i++){
                 checksum += (uint8_t)output[i];
             }
 
-            // Append to line
+            // Append checksum value to end of line, last column 
             char checksumString[8];
             snprintf(checksumString, 8, "%u,", checksum);
             strncat(output, checksumString, MAX_JSON_SIZE);
@@ -166,20 +168,25 @@ bool SDManager::log(DateTime currentTime) {
             // Write the matching data into the CSV file
             myFile.println(output);
 
-            // Sync file, don't close unless EOD
+            // Sync/flush file, don't close unless EOD
             myFile.sync();
 
+            // Checks if the day has chenged, if so we enter and will close, reopen file
             if(currentTime.day() != lastClosed){
+                // Run the checksum by going through the file
+                // If passes verification, close and reopen file
                 if(verifyChecksum(myFile)){
                     myFile.close();
                     myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
                 }
+                // If failed verification, open new file
                 else{
                     myFile.close();
                     // open new file
                     updateCurrentFileName();
                     myFile = sd.open(fileName, O_RDWR | O_CREAT | O_APPEND);
                 }
+                // Update day integer to current time so don't close file until end of next day
                 lastClosed = currentTime.day();
             }
 
@@ -201,18 +208,22 @@ bool SDManager::log(DateTime currentTime) {
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// NEEDS TESTING
+// NEEDS TESTING, what if file is too big to parse through for feather board?
+//////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::verifyChecksum(File myFile){
     char lineBuf[MAX_JSON_SIZE];
     int lineIndex = 0;
     int lineCount = 0;
     
     while(myFile.available()){
+        // Go through every char in file
         char c = myFile.read();
 
+        // When we hit a new line, we start evaluating
         if(c == '\n'){
             lineBuf[lineIndex] = '\0';
 
+            // Find last comma = checksum, don't evaluate on the checksum number since it is point of reference
             char* checksumComma = strrchr(lineBuf, ',');
 
             lineCount++;
@@ -220,29 +231,36 @@ bool SDManager::verifyChecksum(File myFile){
             // Skip headers in csv
             if(lineCount > 3){
                 if(checksumComma != nullptr){
+                    // Get the value to compare to
                     uint16_t actualChecksum = atoi(checksumComma + 1);
 
                     *checksumComma = '\0';
 
+                    // Go through the lineBuf (one line in csv) and manually add checksum
                     uint16_t lineChecksum = 0;
                     for(int i = 0; i < strlen(lineBuf); i++){
                         lineChecksum += (uint8_t)lineBuf[i];
                     }
 
+                    // Compare actual checksum to computed checksum, if fails then file is corrupted
                     if(actualChecksum != lineChecksum){
-                        printModuleName("Error: Checksum Failed");
+                        char buf[64];
+                        snprintf(buf, 64, "Error: Checksum Failed at Line %i", lineCount);
+                        printModuleName(buf);
                         return false;
                     }
                 }
             }
+            // Reset for next line
             lineIndex = 0;
             memset(lineBuf, '\0', MAX_JSON_SIZE);
-
         }
+        // When not at endline, just keep adding to lineBuf that will represent array of csv characters
         else{
             lineBuf[lineIndex++] = c;
         }
     }    
+    // If verification passes, file is not corrupted
     printModuleName("Checksum Passed");
     return true;
 }

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -221,7 +221,7 @@ bool SDManager::verifyChecksum(File &myFile) {
         char c = myFile.read();
 
         // Never let WD timer reset while reading/verifying file
-        WD_TIMER_RESET; 
+        WD_TIMER_RESET;
 
         // When we hit a new line, we start evaluating
         if (c == '\n') {

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -157,20 +157,6 @@ bool SDManager::log(DateTime currentTime) {
                 checksum += (uint8_t)output[i];
             }
 
-            // LEAVE IN FOR TESTING TO ENTER VERIFY CHECKSUM BELOW
-            checksum++;
-            // REMOVE LATER
-
-            // TESTING CHECKSUM VALUE AND CSV LINE HERE TO COMPARE TO VERIFY CHECKSUM BELOW
-            char buf[64];
-            snprintf(buf, 64, "log Checksum: %i", checksum);
-            printModuleName(buf);
-
-            char buff[MAX_JSON_SIZE + 32];
-            snprintf(buff, MAX_JSON_SIZE + 32, "LOG OUTPUT BEFORE APPEND: %s", output);
-            printModuleName(buff);
-            ///////////////////////////////////////////////////////////////////////////
-
             // Append checksum value to end of line, last column 
             char checksumString[8];
             snprintf(checksumString, 8, ",%u", checksum);
@@ -181,10 +167,6 @@ bool SDManager::log(DateTime currentTime) {
 
             // Sync/flush file, don't close unless EOD
             myFile.sync();
-
-            // LEAVE IN FOR TESTING TO ENTER IF BELOW
-            lastClosed++;
-            /////////////////////////////////////////
 
             // Checks if the day has chenged, if so we enter and will close, reopen file
             if(currentTime.day() != lastClosed){
@@ -228,7 +210,6 @@ bool SDManager::log(DateTime currentTime) {
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// NEEDS TESTING
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool SDManager::verifyChecksum(File& myFile){
     myFile.seekSet(0);
@@ -263,19 +244,9 @@ bool SDManager::verifyChecksum(File& myFile){
                         lineChecksum += (uint8_t)lineBuf[i];
                     }
 
-                    // FOR TESTING PURPOSES TO COMPARE CHECKSUM VALUES AND LINE OUTPUTS
-                    char buf[64];
-                    snprintf(buf, 64, "checksum from csv: %i, computed checksum: %i", actualChecksum, lineChecksum);
-                    printModuleName(buf);
-
-                    char buff[MAX_JSON_SIZE + 32];
-                    snprintf(buff, MAX_JSON_SIZE + 32, "VERIFY LINE OUTPUT: %s", lineBuf);
-                    printModuleName(buff);
-                    ///////////////////////////////////////////////////////////////////////////
-
                     // Compare actual checksum to computed checksum, if fails then file is corrupted
                     if(actualChecksum != lineChecksum){
-                        // char buf[64];
+                        char buf[64];
                         snprintf(buf, 64, "Error: Checksum Failed at Line %i", lineCount);
                         ERROR(buf);
                         return false;

--- a/src/Hardware/Loom_Hypnos/SDManager.cpp
+++ b/src/Hardware/Loom_Hypnos/SDManager.cpp
@@ -201,6 +201,7 @@ bool SDManager::log(DateTime currentTime) {
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// NEEDS TESTING
 bool SDManager::verifyChecksum(File myFile){
     char lineBuf[MAX_JSON_SIZE];
     int lineIndex = 0;
@@ -236,7 +237,7 @@ bool SDManager::verifyChecksum(File myFile){
             }
             lineIndex = 0;
             memset(lineBuf, '\0', MAX_JSON_SIZE);
-            
+
         }
         else{
             lineBuf[lineIndex++] = c;

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -49,7 +49,7 @@ class SDManager : public Module {
      * Checks line by line the file's contents and evalutes a checksum that
      * is compared to the appended checksum computed from log
      */
-    bool verifyChecksum(File& myFile);
+    bool verifyChecksum(File &myFile);
 
     /**
      * Read the contents of a given file on the SD card and return them as a string
@@ -117,11 +117,11 @@ class SDManager : public Module {
     /* Get whatever number we are currently appending to the SD fileNames*/
     int getCurrentFileNumber() { return file_count; };
 
-    private:
+  private:
     Manager *manInst; // Reference to the manager
 
     File myFile;       // File object used to handle reading and writing
-    File batchFile;    // for txt file, not csv 
+    File batchFile;    // for txt file, not csv
     File scanningFile; // Used specifically to search through the directory
     File root;         // Open the root directory as a file
 

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -50,7 +50,7 @@ class SDManager : public Module {
      * Checks line by line the file's contents and evalutes a checksum that
      * is compared to the appended checksum computed from log
      */
-    bool verifyChecksum(File myFile);
+    bool verifyChecksum(File& myFile);
 
     /**
      * Read the contents of a given file on the SD card and return them as a string

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -117,7 +117,7 @@ class SDManager : public Module {
     File scanningFile; // Used specifically to search through the directory
     File root;         // Open the root directory as a file
 
-    int lastClosed = -1;
+    int lastClosed = 0;
 
     SdFat sd; // SD Card Object
 

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -40,11 +40,15 @@ class SDManager : public Module {
      * Log the current sensor data to the SD card
      * @param currentTime The current time provided by the RTC this allows us to set accurate
      * modified/created times for files
+     * Opens and closes once per day
      */
     bool log(DateTime currentTime);
 
     /**
-     * Needs testing
+     * NEEDS TESTING
+     * @param myFile The name of the csv file to verify
+     * Checks line by line the file's contents and evalutes a checksum that
+     * is compared to the appended checksum computed from log
      */
     bool verifyChecksum(File myFile);
 

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -44,6 +44,11 @@ class SDManager : public Module {
     bool log(DateTime currentTime);
 
     /**
+     * Needs testing
+     */
+    bool verifyChecksum(File myFile);
+
+    /**
      * Read the contents of a given file on the SD card and return them as a string
      *
      * YOU MUST FREE THIS BLOCK OF MEMORY AS IT IS 10kb

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -45,7 +45,6 @@ class SDManager : public Module {
     bool log(DateTime currentTime);
 
     /**
-     * NEEDS TESTING
      * @param myFile The name of the csv file to verify
      * Checks line by line the file's contents and evalutes a checksum that
      * is compared to the appended checksum computed from log

--- a/src/Hardware/Loom_Hypnos/SDManager.h
+++ b/src/Hardware/Loom_Hypnos/SDManager.h
@@ -109,12 +109,15 @@ class SDManager : public Module {
     /* Get whatever number we are currently appending to the SD fileNames*/
     int getCurrentFileNumber() { return file_count; };
 
-  private:
+    private:
     Manager *manInst; // Reference to the manager
 
     File myFile;       // File object used to handle reading and writing
+    File batchFile;    // for txt file, not csv 
     File scanningFile; // Used specifically to search through the directory
     File root;         // Open the root directory as a file
+
+    int lastClosed = -1;
 
     SdFat sd; // SD Card Object
 

--- a/src/Sensors/I2C/Loom_DFMultiGasSensor/Loom_DFMultiGasSensor.cpp
+++ b/src/Sensors/I2C/Loom_DFMultiGasSensor/Loom_DFMultiGasSensor.cpp
@@ -59,7 +59,7 @@ void Loom_DFMultiGasSensor::measure() {
         if (checkDeviceConnection()) {
 
             // Update the current gas type
-            currentGasType = gasSensor.queryGasType();
+            currentGasType = gasSensor.queryGasType().c_str();
             if (strlen(currentGasType) <= 0) {
                 currentGasType = "INV_TYPE";
             }

--- a/src/Sensors/I2C/Loom_DFMultiGasSensor/Loom_DFMultiGasSensor.h
+++ b/src/Sensors/I2C/Loom_DFMultiGasSensor/Loom_DFMultiGasSensor.h
@@ -39,7 +39,7 @@ class Loom_DFMultiGasSensor : public I2CDevice {
     /**
      * Get gas type that is currently being recorded
      */
-    const char *getGasType() { return currentGasType; };
+    String getGasType() { return currentGasType; };
 
     /**
      * Get the gas concentration that is currently being recorded


### PR DESCRIPTION
#207 Changes made to SDManager.cpp and SDManager.h made to reduce SD card open/closes and verify for corruption upon end of the day.

- Changes to SDManager.log():
EOD file/open close
Removed sd.open at start of log()
Moved sd.open to begin() to open first time upon initialization
Replaced myFile.close with myFile.sync to flush and not close
Added conditional to check if next day has arrived,
myFile.close, then sd.open, update day number 
Added integer to check day number when last closed, initialized in log when file never written to before
Since logBatch() writing to txt file overwrites myFile, added separate file object that will update every iteration unlike myFile which no longer does
Temporary file objects in readFile/writelinetoFile instead of myFile
Tested so EOD condition enters, myFile persists through sleep, and csv files not corrupted.

- Added function SDManager.verifyChecksum():
In log, upon every write of a line to csv, add a checksum that is appended to the end as a column labeled “checksum”
Added function that takes file and parses line by line, checking the provided checksum value and comparing to the whole line’s checksum computed
If returns false, updatecurrentfilename and open new file as last one is corrupted


**Had to make changes to DFMultigas sensor so it would compile, just changing char* to String**