### PR TITLE
Bugfix for Loom_Multiplexer.h and SHT31.ino

### DIFF
--- a/examples/Hypnos/Hypnos_RTC_SD_Timezone/Hypnos_RTC_SD_Timezone.ino
+++ b/examples/Hypnos/Hypnos_RTC_SD_Timezone/Hypnos_RTC_SD_Timezone.ino
@@ -25,11 +25,12 @@ void setup() {
   // Start and wait for the user to open the Serial monitor
   manager.beginSerial();
 
-  // Load the Timezone before we enable the hypnos
+  // Enable the hypnos rails first
+  hypnos.enable();
+
+  // Load the Timezone after we enable the hypnos
   hypnos.getConfigFromSD("HypnosConfig.json");
 
-  // Enable the hypnos rails
-  hypnos.enable();
 }
 
 void loop() {

--- a/examples/Internet/Logging/LTEMongoDBBatch/LTEMongoDBBatch.ino
+++ b/examples/Internet/Logging/LTEMongoDBBatch/LTEMongoDBBatch.ino
@@ -7,6 +7,7 @@
 
 #include <Loom_Manager.h>
 
+#include <Sensors/Loom_Analog/Loom_Analog.h>
 #include <Hardware/Loom_Hypnos/Loom_Hypnos.h>
 #include <Internet/Connectivity/Loom_LTE/Loom_LTE.h>
 #include <Internet/Logging/Loom_MongoDB/Loom_MongoDB.h>
@@ -15,14 +16,18 @@ Manager manager("Device", 1);
 
 Loom_Hypnos hypnos(manager, HYPNOS_VERSION::V3_3, TIME_ZONE::PST);
 
+// Enables read for battery voltage
+Loom_Analog analog(manager);
+
 Loom_LTE lte(manager, NETWORK_NAME, NETWORK_USER, NETWORK_PASS);
-Loom_MongoDB mqtt(manager, lte.getClient(), SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
+Loom_MongoDB mqtt(manager, lte, SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
 
 // Enables batch logging with a batch size of 15
 Loom_BatchSD batchSD(hypnos, 15);
 
 // Called when the interrupt is triggered 
 void isrTrigger(){
+
   hypnos.wakeup();
 }
 
@@ -50,7 +55,7 @@ void loop() {
   hypnos.setInterruptDuration(TimeSpan(0, 0, 0, 10));
 
   // Measure data from connected sensors
-  manager.measure()
+  manager.measure();
     
   // Package data
   manager.package();

--- a/examples/Internet/Logging/ThingSpeak/ThingSpeak.ino
+++ b/examples/Internet/Logging/ThingSpeak/ThingSpeak.ino
@@ -26,7 +26,7 @@ Loom_WIFI wifi(manager, CommunicationMode::CLIENT, SECRET_SSID, SECRET_PASS);
 //Loom_LTE lte(manager, NETWORK_NAME, NETWORK_USER, NETWORK_PASS);
 
 // WiFi
-Loom_ThingSpeak thingspeak(manager, wifi.getClient(), CHANNEL_ID, CLIENT_ID, BROKER_USER, BROKER_PASS);
+Loom_ThingSpeak thingspeak(manager, wifi, CHANNEL_ID, CLIENT_ID, BROKER_USER, BROKER_PASS);
 
 // LTE
 //Loom_ThingSpeak mqtt(manager, lte.getClient(), CHANNEL_ID, CLIENT_ID, BROKER_USER, BROKER_PASS);

--- a/examples/Internet/Logging/WiFiMongoDB/WiFiMongoDB.ino
+++ b/examples/Internet/Logging/WiFiMongoDB/WiFiMongoDB.ino
@@ -13,7 +13,7 @@
 Manager manager("Device", 1);
 
 Loom_WIFI wifi(manager, CommunicationMode::CLIENT, SECRET_SSID, SECRET_PASS);
-Loom_MongoDB mqtt(manager, wifi.getClient(), SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
+Loom_MongoDB mqtt(manager, wifi, SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
 
 void setup() {
   manager.beginSerial();

--- a/examples/Internet/Logging/WiFiMongoDBBatch/WiFiMongoDBBatch.ino
+++ b/examples/Internet/Logging/WiFiMongoDBBatch/WiFiMongoDBBatch.ino
@@ -7,6 +7,7 @@
 
 #include <Loom_Manager.h>
 
+#include <Sensors/Loom_Analog/Loom_Analog.h>
 #include <Hardware/Loom_Hypnos/Loom_Hypnos.h>
 #include <Internet/Connectivity/Loom_Wifi/Loom_Wifi.h>
 #include <Internet/Logging/Loom_MongoDB/Loom_MongoDB.h>
@@ -15,8 +16,11 @@ Manager manager("Device", 1);
 
 Loom_Hypnos hypnos(manager, HYPNOS_VERSION::V3_3, TIME_ZONE::PST);
 
+// Enables read for battery voltage
+Loom_Analog analog(manager);
+
 Loom_WIFI wifi(manager, CommunicationMode::CLIENT, SECRET_SSID, SECRET_PASS);
-Loom_MongoDB mqtt(manager, wifi.getClient(), SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
+Loom_MongoDB mqtt(manager, wifi, SECRET_BROKER, SECRET_PORT, DATABASE, BROKER_USER, BROKER_PASS, PROJECT);
 
 // Enables batch logging with a batch size of 15
 Loom_BatchSD batchSD(hypnos, 15);

--- a/examples/Sensors/I2C/DFMultiGasSensor/DFMultiGasSensor.ino
+++ b/examples/Sensors/I2C/DFMultiGasSensor/DFMultiGasSensor.ino
@@ -3,13 +3,17 @@
  */
 #include <Loom_Manager.h>
 #include <Sensors/I2C/Loom_DFMultiGasSensor/Loom_DFMultiGasSensor.h>
-
+#include <Hardware/Loom_Multiplexer/Loom_Multiplexer.h>
 
 // If the sensor is freezing on init try disconnecting the power and re-connecting it
 Manager manager("Device", 1);
 
 // MANAGER, I2C ADDRESS, INIT RETRY LIMIT, USE MUX
 Loom_DFMultiGasSensor gas(manager, 0x77, 10, false);
+
+// If using Multiplexer, use base addr 0x74
+// Loom_Multiplexer mux(manager, {0x74});
+
 
 void setup() {
   manager.beginSerial();

--- a/examples/Sensors/I2C/MS5803_2_Sensors/MS5803_2_Sensors.ino
+++ b/examples/Sensors/I2C/MS5803_2_Sensors/MS5803_2_Sensors.ino
@@ -10,12 +10,15 @@
 
 #include <Loom_Manager.h>
 
+#include <Hardware/Loom_Hypnos/Loom_Hypnos.h>
 #include <Sensors/I2C/Loom_MS5803/Loom_MS5803.h>
 
 Manager manager("Device", 1);
 
-Loom_MS5803 ms_water(manager, 0x77, false); // MS5803 CSB pin tied to VCC i2c addr 0x77
-Loom_MS5803 ms_air(manager, 0x76, false); // MS5803 CSB pin tied to VCC i2c addr 0x76
+Loom_Hypnos hypnos(manager, HYPNOS_VERSION::V3_3, TIME_ZONE::PST);
+
+Loom_MS5803 ms_water(manager, 119, false); // MS5803 CSB pin tied to VCC i2c addr 0x77
+Loom_MS5803 ms_air(manager, 118, false); // MS5803 CSB pin tied to VCC i2c addr 0x76
 
 
 /* Calculate the water height based on the difference of pressures*/
@@ -28,6 +31,8 @@ void setup() {
 
   // Start the serial interface
   manager.beginSerial();
+
+  hypnos.enable();
 
   // Initialize the manager
   manager.initialize();

--- a/examples/Sensors/I2C/SHT31/SHT31.ino
+++ b/examples/Sensors/I2C/SHT31/SHT31.ino
@@ -19,6 +19,7 @@ void setup() {
   // Start the serial interface
   manager.beginSerial();
 
+  // Enable hypnos for RTC
   hypnos.enable();
 
   // Initialize the manager

--- a/examples/Sensors/I2C/SHT31/SHT31.ino
+++ b/examples/Sensors/I2C/SHT31/SHT31.ino
@@ -19,6 +19,8 @@ void setup() {
   // Start the serial interface
   manager.beginSerial();
 
+  hypnos.enable();
+
   // Initialize the manager
   manager.initialize();
 }

--- a/examples/Sensors/I2C/TSL2591/TSL2591.ino
+++ b/examples/Sensors/I2C/TSL2591/TSL2591.ino
@@ -20,6 +20,9 @@ void setup() {
   // Start the serial interface
   manager.beginSerial();
 
+  // Enable hypnos for RTC
+  hypnos.enable();
+
   // Initialize the manager
   manager.initialize();
 }

--- a/src/Hardware/Loom_Multiplexer/Loom_Multiplexer.h
+++ b/src/Hardware/Loom_Multiplexer/Loom_Multiplexer.h
@@ -100,5 +100,5 @@ class Loom_Multiplexer : public Module {
     /**
      * Possible alternate addresses for the TCA9548
      */
-    const std::array<byte, 9> alt_addresses = {0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x78};
+    const std::array<byte, 9> alt_addresses = {0x71, 0x72, 0x73, 0x74, 0x75, 0x78};
 };

--- a/src/Hardware/Loom_Multiplexer/Loom_Multiplexer.h
+++ b/src/Hardware/Loom_Multiplexer/Loom_Multiplexer.h
@@ -100,5 +100,5 @@ class Loom_Multiplexer : public Module {
     /**
      * Possible alternate addresses for the TCA9548
      */
-    const std::array<byte, 9> alt_addresses = {0x71, 0x72, 0x73, 0x74, 0x75, 0x78};
+    const std::array<byte, 9> alt_addresses = {0x70, 0x71, 0x72, 0x73, 0x74, 0x75, 0x78};
 };

--- a/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31865.cpp
+++ b/src/Sensors/SPI/Loom_MAX318XX/Loom_MAX31865.cpp
@@ -2,7 +2,7 @@
 #include "Logger.h"
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
-Loom_MAX31865::Loom_MAX31865(Manager &man, int samples, int chip_select)
+Loom_MAX31865::Loom_MAX31865(Manager &man, int chip_select, int samples)
     : Module("MAX31865"), manInst(&man), max(chip_select), num_samples(samples) {
     manInst->registerModule(this);
 }


### PR DESCRIPTION
Loom_Multiplexer.h
- Added default bit address 0x70 for the TCA9548A MUX to the array of alternate addresses.

SHT31.ino 
- Added hypnos.enable to setup()