### PR TITLE
added seperate package index file for pre-release beta testing

### DIFF
--- a/auxilary/package_loom4_beta_index.json
+++ b/auxilary/package_loom4_beta_index.json
@@ -1,0 +1,34 @@
+{
+  "packages": [
+    {
+      "name": "loom4-beta",
+      "maintainer": "OPEnS Lab",
+      "websiteURL": "https://github.com/OPEnSLab-OSU/Loom-V4",
+      "email": "open.sensing@oregonstate.edu",
+      "help":{
+        "online": "https://github.com/OPEnSLab-OSU/Loom-V4/issues"
+      },
+      "platforms": [
+        {
+          "name": "Loom SAMD Boards V4 Beta",
+          "architecture": "samd",
+          "version": "4.9.1-beta.1",
+          "category": "contributed",
+          "help": {
+            "online": "https://github.com/OPEnSLab-OSU/Loom-V4/issues"
+          },
+          "url": "https://github.com/OPEnSLab-OSU/Loom-V4/releases/download/v4.9.1-beta.1/loom4_beta.zip",
+          "archiveFileName": "loom4.zip",
+          "checksum": "SHA-256:e119b72fe3f66cbdb6b1134084d8d23cedfe1ffab12b9493e6363360079d0ad5",
+          "size": "24625528",
+          "boards": [
+            {
+              "name": "Loomified Adafruit Feather M0 (SAMD21)"
+            }
+          ]
+        }
+      ],
+      "tools":[]
+    }
+  ]
+}


### PR DESCRIPTION
Separates production package from beta package, allows beta testers to safely test and switch back to their production branches, keeping local changes from being discarded. 