### PR TITLE
Added daylight savings fix

### DIFF
--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -300,20 +300,57 @@ DateTime Loom_Hypnos::getLocalTime(DateTime time) {
         return time + TimeSpan(0, (timezone), 0, 0);
     }
 }
-///////////////////////////////////////
-//////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+bool Loom_Hypnos::isDaylightSavingsForDate(const DateTime &now, TIME_ZONE zone) {
+    // Timezones that observe US daylight savings (added MST)
+    switch (zone) {
+    case AST:
+    case EST:
+    case CST:
+    case MST:
+    case PST:
+    case AKST:
+        break;
+    default:
+        return false;
+    }
+
+    int year = now.year();
+
+    DateTime dstStart = nthWeekdayOfMonth(year, 3, 0, 2, 2);
+    DateTime dstEnd = nthWeekdayOfMonth(year, 11, 0, 1, 2);
+
+    return (now >= dstStart) && (now < dstEnd);
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 bool Loom_Hypnos::isDaylightSavings() {
-    // Timezones that observe daylight savings
-    if (timezone == AST || timezone == EST || timezone == CST || timezone == AST ||
-        timezone == PST || timezone == AKST) {
-        int currMonth = getCurrentTime().month();
 
-        // If we are in the months where daylight savings is in affect
-        return (currMonth >= 3 && currMonth < 11);
+    return isDaylightSavingsForDate(getCurrentTime(), timezone);
+}
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+DateTime Loom_Hypnos::nthWeekdayOfMonth(int year, int month, int dow, int week, int hour) {
+    DateTime firstOfMonth(year, month, 1, 0, 0, 0);
+    int firstDow = firstOfMonth.dayOfTheWeek();
+    int day = 1 + ((dow - firstDow + 7) % 7);
+
+    if (week == 0) {
+        // first day of week: step forward a week at a time while still in month
+        static const int daysInMonthTable[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        int dim = daysInMonthTable[month - 1];
+        if (month == 2 && ((year % 4 == 0 && year % 100 != 0) || year % 400 == 0))
+            dim = 29;
+        while (day + 7 <= dim)
+            day += 7;
+    } else {
+        day += (week - 1) * 7;
     }
-    return false;
+    return DateTime(year, month, day, hour, 0, 0);
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -319,8 +319,8 @@ bool Loom_Hypnos::isDaylightSavingsForDate(const DateTime &now, TIME_ZONE zone) 
 
     int year = now.year();
 
-    DateTime dstStartLocalStd = nthWeekdayOfMonth(year, 3, 0, 2, 2);  // 2nd Sun of March
-    DateTime dstEndLocalDst = nthWeekdayOfMonth(year, 11, 0, 1, 2);   // 1st Sun of November
+    DateTime dstStartLocalStd = nthWeekdayOfMonth(year, 3, 0, 2, 2); // 2nd Sun of March
+    DateTime dstEndLocalDst = nthWeekdayOfMonth(year, 11, 0, 1, 2);  // 1st Sun of November
 
     int standardOffsetHours = (int)zone;
     int daylightOffsetHours = standardOffsetHours + 1;

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.cpp
@@ -319,10 +319,19 @@ bool Loom_Hypnos::isDaylightSavingsForDate(const DateTime &now, TIME_ZONE zone) 
 
     int year = now.year();
 
-    DateTime dstStart = nthWeekdayOfMonth(year, 3, 0, 2, 2);
-    DateTime dstEnd = nthWeekdayOfMonth(year, 11, 0, 1, 2);
+    DateTime dstStartLocalStd = nthWeekdayOfMonth(year, 3, 0, 2, 2);  // 2nd Sun of March
+    DateTime dstEndLocalDst = nthWeekdayOfMonth(year, 11, 0, 1, 2);   // 1st Sun of November
 
-    return (now >= dstStart) && (now < dstEnd);
+    int standardOffsetHours = (int)zone;
+    int daylightOffsetHours = standardOffsetHours + 1;
+
+    // Convert each boundary to UTC using its own fixed offset
+    uint32_t dstStartUTC = dstStartLocalStd.unixtime() - (int32_t)standardOffsetHours * 3600;
+    uint32_t dstEndUTC = dstEndLocalDst.unixtime() - (int32_t)daylightOffsetHours * 3600;
+
+    uint32_t nowUTC = now.unixtime();
+
+    return (nowUTC >= dstStartUTC) && (nowUTC < dstEndUTC);
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/Hardware/Loom_Hypnos/Loom_Hypnos.h
+++ b/src/Hardware/Loom_Hypnos/Loom_Hypnos.h
@@ -48,7 +48,7 @@ enum TIME_ZONE {
     MST = -7,
     PST = -8,
     AKST = -9,
-    HST = -9,
+    HST = -10,
     SST = -11,
     GMT = 0,
     BST = 1,
@@ -240,6 +240,10 @@ class Loom_Hypnos : public Module {
 
     /* Whether or not the current timezone is observing daylight savings */
     bool isDaylightSavings();
+
+    /*Daylight Savings Implementation*/
+    static DateTime nthWeekdayOfMonth(int year, int month, int dow, int week, int hour);
+    static bool isDaylightSavingsForDate(const DateTime &now, TIME_ZONE zone);
 
     /**
      * Set an alternative name to log data to


### PR DESCRIPTION
My additions for a daylight savings fix. 
~ I added nthweekofmonth: which calculates the first Sunday's date, then jumps n number of weeks to find the date for DST. This uses a modulo equation for (dow - firstDow + 7) % 7, where day of week is a number between 0-6 (being Sunday = 0, Monday = 1, Tuesday = 2, up to Saturday = 6). For March 2027, this calculates to: 1 + (0 - 1 + 7) % 7 = 1+ 6 % 7 = 7, which makes the first Sunday of March, the 7th. 
~ I added isdatefordaylightsavings as it hardcodes important information that doesn't change per year such as: 
 - the month DST lands on: March/November
 - which occurrence of that weekday marks the transition: 2nd Sunday for March, 1st Sunday for November
 - the hour the transition occurs: 2:00 AM
